### PR TITLE
Fix GitHub Actions test failures

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
       run: uv sync --all-extras
 
     - name: Run tests
-      run: uv run pytest --cov=src/rag_evaluator --cov-report=term-missing
+      run: uv run pytest
 
     - name: Run linting
       run: uv run ruff check .

--- a/scripts/test_chroma_rag.py
+++ b/scripts/test_chroma_rag.py
@@ -38,7 +38,7 @@ def main() -> None:
 
     # Get initial metrics
     metrics = rag.get_metrics()
-    print(f"\n3. Initial Metrics:")
+    print("\n3. Initial Metrics:")
     print(f"   - Total chunks: {metrics['total_chunks']}")
     print(f"   - Collection: {metrics['collection_name']}")
 
@@ -62,7 +62,7 @@ def main() -> None:
 
     # Final metrics
     final_metrics = rag.get_metrics()
-    print(f"\n5. Final Metrics:")
+    print("\n5. Final Metrics:")
     print(f"   - Total queries: {final_metrics['total_queries']}")
     print(f"   - Avg retrieval time: {final_metrics['avg_retrieval_time']:.3f}s")
 


### PR DESCRIPTION
- Remove duplicate coverage arguments from pytest command in CI workflow
  (already configured in pyproject.toml addopts)
- Fix linting errors in test script (remove unnecessary f-string prefixes)

The issue was that --cov arguments were being passed both via command line
and via pyproject.toml configuration, causing pytest to error with
"unrecognized arguments" in the CI environment.