### PR TITLE
feat: add evaluation comparison UI

### DIFF
--- a/platform/backend/app/schemas/comparison.py
+++ b/platform/backend/app/schemas/comparison.py
@@ -95,6 +95,12 @@ class AggregateMetrics(BaseSchema):
     """Schema for aggregate comparison metrics."""
 
     baseline_evaluation_id: UUID = Field(description="Baseline evaluation ID")
+    baseline_evaluation_name: str | None = Field(
+        default=None, description="Baseline evaluation name/notes"
+    )
+    baseline_rag_config_name: str | None = Field(
+        default=None, description="Baseline RAG config name"
+    )
     baseline_summary: SummaryMetrics | None = Field(default=None)
     baseline_cost: CostMetrics | None = Field(default=None)
     baseline_performance: PerformanceMetrics | None = Field(default=None)

--- a/platform/backend/app/services/comparison_service.py
+++ b/platform/backend/app/services/comparison_service.py
@@ -187,6 +187,9 @@ class ComparisonService:
         baseline_summary = self._eval_to_summary_metrics(baseline_eval)
         baseline_cost = self._eval_to_cost_metrics(baseline_eval)
         baseline_performance = self._eval_to_performance_metrics(baseline_eval)
+        baseline_rag_config_name = (
+            baseline_eval.rag_config.name if baseline_eval.rag_config else None
+        )
 
         comparison_results: list[EvaluationComparisonResult] = []
 
@@ -224,6 +227,8 @@ class ComparisonService:
 
         return AggregateMetrics(
             baseline_evaluation_id=baseline_eval.id,
+            baseline_evaluation_name=baseline_eval.notes,
+            baseline_rag_config_name=baseline_rag_config_name,
             baseline_summary=baseline_summary,
             baseline_cost=baseline_cost,
             baseline_performance=baseline_performance,
@@ -274,6 +279,7 @@ class ComparisonService:
                     "relevancy": baseline_result.relevancy_score,
                     "precision": baseline_result.precision_score,
                     "recall": baseline_result.recall_score,
+                    "g_eval": baseline_result.g_eval_score,
                     "latency_seconds": baseline_result.latency_seconds,
                     "generated_answer": baseline_result.generated_answer,
                 }
@@ -290,6 +296,7 @@ class ComparisonService:
                         "relevancy": compared_result.relevancy_score,
                         "precision": compared_result.precision_score,
                         "recall": compared_result.recall_score,
+                        "g_eval": compared_result.g_eval_score,
                         "latency_seconds": compared_result.latency_seconds,
                         "generated_answer": compared_result.generated_answer,
                     }

--- a/platform/frontend/src/api/client.ts
+++ b/platform/frontend/src/api/client.ts
@@ -590,6 +590,79 @@ export interface PlaygroundQueryDetail {
   results: PlaygroundQueryResult[]
 }
 
+// Comparisons
+export interface CostMetrics {
+  total_cost_usd?: number | string
+  total_prompt_tokens?: number
+  total_completion_tokens?: number
+  avg_cost_per_query?: number | string | null
+}
+
+export interface PerformanceMetrics {
+  avg_latency_seconds?: number | null
+  min_latency_seconds?: number | null
+  max_latency_seconds?: number | null
+  p95_latency_seconds?: number | null
+}
+
+export interface MetricDelta {
+  baseline_value: number | null
+  compared_value: number | null
+  absolute_delta: number | null
+  percentage_delta: number | null
+  improved: boolean | null
+}
+
+export interface EvaluationComparisonResult {
+  evaluation_id: string
+  evaluation_name?: string | null
+  rag_config_name?: string | null
+  summary_metrics?: SummaryMetrics | null
+  cost_metrics?: CostMetrics | null
+  performance_metrics?: PerformanceMetrics | null
+  pass_rate?: number | null
+}
+
+export interface PerQuestionDelta {
+  test_case_id: string
+  question?: string | null
+  baseline_result?: Record<string, unknown> | null
+  compared_results: Record<string, Record<string, unknown>>
+}
+
+export interface AggregateMetrics {
+  baseline_evaluation_id: string
+  baseline_evaluation_name?: string | null
+  baseline_rag_config_name?: string | null
+  baseline_summary?: SummaryMetrics | null
+  baseline_cost?: CostMetrics | null
+  baseline_performance?: PerformanceMetrics | null
+  baseline_pass_rate?: number | null
+  comparison_results: EvaluationComparisonResult[]
+}
+
+export interface ComparisonResponse {
+  id: string
+  project_id: string
+  name?: string | null
+  description?: string | null
+  baseline_evaluation_id: string
+  compared_evaluation_ids: string[]
+  aggregate_metrics?: AggregateMetrics | null
+  created_at: string
+}
+
+export interface ComparisonDetail extends ComparisonResponse {
+  per_question_deltas?: PerQuestionDelta[] | null
+}
+
+export interface ComparisonCreate {
+  name?: string
+  description?: string
+  baseline_evaluation_id: string
+  compared_evaluation_ids: string[]
+}
+
 // API functions
 export const api = {
   health: {
@@ -721,6 +794,15 @@ export const api = {
       apiClient.get<ProjectTrends>(`/projects/${projectId}/trends`),
     getRagConfigTrends: (ragConfigId: string) =>
       apiClient.get<RAGConfigTrend>(`/rag-configs/${ragConfigId}/trends`),
+  },
+  comparisons: {
+    list: (projectId: string, params?: { limit?: number; offset?: number }) =>
+      apiClient.get<PaginatedList<ComparisonResponse>>(`/projects/${projectId}/comparisons`, { params }),
+    get: (id: string) => apiClient.get<ComparisonDetail>(`/comparisons/${id}`),
+    create: (data: ComparisonCreate) => apiClient.post<ComparisonResponse>('/comparisons', data),
+    delete: (id: string) => apiClient.delete(`/comparisons/${id}`),
+    listForEvaluation: (evaluationId: string, params?: { limit?: number; offset?: number }) =>
+      apiClient.get<PaginatedList<ComparisonResponse>>(`/evaluations/${evaluationId}/comparisons`, { params }),
   },
   playground: {
     getIndexes: (params?: { project_id?: string; kb_id?: string }) =>

--- a/platform/frontend/src/components/comparisons/ComparisonCharts.tsx
+++ b/platform/frontend/src/components/comparisons/ComparisonCharts.tsx
@@ -1,0 +1,119 @@
+import {
+    BarChart,
+    Bar,
+    XAxis,
+    YAxis,
+    CartesianGrid,
+    Tooltip,
+    Legend,
+    ResponsiveContainer,
+    RadarChart,
+    Radar,
+    PolarGrid,
+    PolarAngleAxis,
+    PolarRadiusAxis,
+    ScatterChart,
+    Scatter,
+    ZAxis,
+} from 'recharts'
+import { ComparisonMember, METRIC_ROWS } from './compare-utils'
+
+const COLORS = ['#2563eb', '#16a34a', '#d97706', '#dc2626', '#7c3aed', '#0891b2', '#db2777', '#65a30d', '#ea580c', '#4f46e5']
+
+interface ComparisonChartsProps {
+    members: ComparisonMember[]
+}
+
+export function ComparisonCharts({ members }: ComparisonChartsProps) {
+    const scoreRows = METRIC_ROWS.filter((r) => r.isScore)
+
+    const barData = scoreRows.map((row) => {
+        const entry: Record<string, string | number | null> = { metric: row.label }
+        members.forEach((m) => {
+            entry[m.id] = row.get(m)
+        })
+        return entry
+    })
+
+    const radarData = barData // same shape works for radar
+
+    const overallRow = METRIC_ROWS.find((r) => r.key === 'overall')!
+    const costRow = METRIC_ROWS.find((r) => r.key === 'avg_cost')!
+    const scatterData = members
+        .map((m, i) => ({
+            name: m.label,
+            cost: costRow.get(m),
+            overall: overallRow.get(m),
+            fill: COLORS[i % COLORS.length],
+        }))
+        .filter((d) => d.cost !== null && d.overall !== null)
+
+    return (
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+            <ChartCard title="Quality metrics">
+                <ResponsiveContainer width="100%" height={300}>
+                    <BarChart data={barData} margin={{ top: 8, right: 8, left: -16, bottom: 0 }}>
+                        <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
+                        <XAxis dataKey="metric" tick={{ fontSize: 11 }} />
+                        <YAxis domain={[0, 1]} tick={{ fontSize: 11 }} />
+                        <Tooltip
+                            contentStyle={{ fontSize: 12, borderRadius: 8 }}
+                            formatter={(v: number) => (v === null ? '—' : v.toFixed(3))}
+                            labelFormatter={() => ''}
+                        />
+                        <Legend wrapperStyle={{ fontSize: 11 }} />
+                        {members.map((m, i) => (
+                            <Bar key={m.id} dataKey={m.id} name={m.label} fill={COLORS[i % COLORS.length]} radius={[3, 3, 0, 0]} />
+                        ))}
+                    </BarChart>
+                </ResponsiveContainer>
+            </ChartCard>
+
+            <ChartCard title="Metric shape (radar)">
+                <ResponsiveContainer width="100%" height={300}>
+                    <RadarChart data={radarData} outerRadius="70%">
+                        <PolarGrid className="stroke-border" />
+                        <PolarAngleAxis dataKey="metric" tick={{ fontSize: 11 }} />
+                        <PolarRadiusAxis domain={[0, 1]} tick={{ fontSize: 10 }} />
+                        <Tooltip contentStyle={{ fontSize: 12, borderRadius: 8 }} formatter={(v: number) => (v === null ? '—' : v.toFixed(3))} />
+                        <Legend wrapperStyle={{ fontSize: 11 }} />
+                        {members.map((m, i) => (
+                            <Radar key={m.id} dataKey={m.id} name={m.label} stroke={COLORS[i % COLORS.length]} fill={COLORS[i % COLORS.length]} fillOpacity={0.15} />
+                        ))}
+                    </RadarChart>
+                </ResponsiveContainer>
+            </ChartCard>
+
+            {scatterData.length > 0 && (
+                <ChartCard title="Cost vs. quality" subtitle="Lower cost and higher overall is better (top-left)">
+                    <ResponsiveContainer width="100%" height={300}>
+                        <ScatterChart margin={{ top: 8, right: 16, left: -16, bottom: 8 }}>
+                            <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
+                            <XAxis type="number" dataKey="cost" name="Cost / query" tick={{ fontSize: 11 }} tickFormatter={(v) => `$${Number(v).toFixed(4)}`} />
+                            <YAxis type="number" dataKey="overall" name="Overall" domain={[0, 1]} tick={{ fontSize: 11 }} />
+                            <ZAxis range={[120, 120]} />
+                            <Tooltip
+                                cursor={{ strokeDasharray: '3 3' }}
+                                contentStyle={{ fontSize: 12, borderRadius: 8 }}
+                                formatter={(v: number, name: string) => (name === 'Cost / query' ? `$${Number(v).toFixed(4)}` : Number(v).toFixed(3))}
+                            />
+                            <Scatter data={scatterData} />
+                        </ScatterChart>
+                    </ResponsiveContainer>
+                </ChartCard>
+            )}
+        </div>
+    )
+}
+
+function ChartCard({ title, subtitle, children }: { title: string; subtitle?: string; children: React.ReactNode }) {
+    return (
+        <div className="rounded-xl border border-border bg-card p-4">
+            <div className="mb-3">
+                <h4 className="text-sm font-bold">{title}</h4>
+                {subtitle && <p className="text-xs text-muted-foreground">{subtitle}</p>}
+            </div>
+            {children}
+        </div>
+    )
+}

--- a/platform/frontend/src/components/comparisons/ComparisonDetail.tsx
+++ b/platform/frontend/src/components/comparisons/ComparisonDetail.tsx
@@ -1,0 +1,116 @@
+import { useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { ArrowLeft, Loader2, AlertCircle, BarChart3, Table2, ListChecks, Settings2 } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { api } from '@/api/client'
+import { buildMembers } from './compare-utils'
+import { MetricMatrix } from './MetricMatrix'
+import { ComparisonCharts } from './ComparisonCharts'
+import { PerQuestionTable } from './PerQuestionTable'
+import { ConfigDiff } from './ConfigDiff'
+
+interface ComparisonDetailProps {
+    comparisonId: string
+    onBack: () => void
+}
+
+type Section = 'metrics' | 'charts' | 'questions' | 'config'
+
+const SECTIONS: { id: Section; name: string; icon: typeof Table2 }[] = [
+    { id: 'metrics', name: 'Metrics', icon: Table2 },
+    { id: 'charts', name: 'Charts', icon: BarChart3 },
+    { id: 'questions', name: 'Per-question', icon: ListChecks },
+    { id: 'config', name: 'Config diff', icon: Settings2 },
+]
+
+export function ComparisonDetail({ comparisonId, onBack }: ComparisonDetailProps) {
+    const [section, setSection] = useState<Section>('metrics')
+    const [baselineId, setBaselineId] = useState<string | null>(null)
+
+    const { data, isLoading, isError } = useQuery({
+        queryKey: ['comparison', comparisonId],
+        queryFn: () => api.comparisons.get(comparisonId),
+    })
+
+    if (isLoading) {
+        return (
+            <div className="flex justify-center py-20">
+                <Loader2 className="h-8 w-8 animate-spin text-primary/50" />
+            </div>
+        )
+    }
+
+    if (isError || !data?.data) {
+        return (
+            <div className="flex flex-col items-center justify-center rounded-xl border border-dashed border-border py-20">
+                <AlertCircle className="h-10 w-10 text-destructive/50" />
+                <p className="mt-4 font-medium">Could not load this comparison.</p>
+                <button onClick={onBack} className="mt-4 text-sm text-primary hover:underline">Back to comparisons</button>
+            </div>
+        )
+    }
+
+    const comparison = data.data
+    const members = buildMembers(comparison.aggregate_metrics)
+    const storedBaselineId = comparison.baseline_evaluation_id
+    const activeBaselineId = baselineId ?? storedBaselineId
+
+    return (
+        <div className="space-y-6">
+            <button onClick={onBack} className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors">
+                <ArrowLeft className="h-4 w-4" />
+                Back to Comparisons
+            </button>
+
+            <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+                <div>
+                    <h2 className="text-xl font-semibold">{comparison.name || 'Untitled comparison'}</h2>
+                    {comparison.description && <p className="text-sm text-muted-foreground">{comparison.description}</p>}
+                    <p className="mt-1 text-xs text-muted-foreground">{members.length} evaluations compared</p>
+                </div>
+                <label className="flex items-center gap-2 text-sm">
+                    <span className="text-xs font-bold uppercase tracking-wider text-muted-foreground">Baseline</span>
+                    <select
+                        value={activeBaselineId}
+                        onChange={(e) => setBaselineId(e.target.value)}
+                        className="rounded-lg border border-border bg-card px-3 py-1.5 text-sm font-medium focus:border-primary focus:outline-none"
+                    >
+                        {members.map((m) => (
+                            <option key={m.id} value={m.id}>{m.label}</option>
+                        ))}
+                    </select>
+                </label>
+            </div>
+
+            <div className="flex gap-6 border-b border-border">
+                {SECTIONS.map((s) => (
+                    <button
+                        key={s.id}
+                        onClick={() => setSection(s.id)}
+                        className={cn(
+                            'flex items-center gap-2 pb-3 text-sm font-bold border-b-2 transition-all',
+                            section === s.id ? 'border-primary text-primary' : 'border-transparent text-muted-foreground hover:text-foreground',
+                        )}
+                    >
+                        <s.icon className="h-4 w-4" />
+                        {s.name}
+                    </button>
+                ))}
+            </div>
+
+            <div>
+                {section === 'metrics' && <MetricMatrix members={members} baselineId={activeBaselineId} />}
+                {section === 'charts' && <ComparisonCharts members={members} />}
+                {section === 'questions' && (
+                    <PerQuestionTable
+                        members={members}
+                        storedBaselineId={storedBaselineId}
+                        baselineId={activeBaselineId}
+                        deltas={comparison.per_question_deltas ?? []}
+                    />
+                )}
+                {section === 'config' && <ConfigDiff members={members} />}
+            </div>
+        </div>
+    )
+}

--- a/platform/frontend/src/components/comparisons/ComparisonsTab.tsx
+++ b/platform/frontend/src/components/comparisons/ComparisonsTab.tsx
@@ -1,0 +1,137 @@
+import { useState } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { GitCompare, Plus, Loader2, Calendar, Trash2, ChevronRight } from 'lucide-react'
+import { api } from '@/api/client'
+import { useToast } from '@/components/ui/toast-context'
+import { CreateComparisonDialog } from './CreateComparisonDialog'
+import { ComparisonDetail } from './ComparisonDetail'
+
+export function ComparisonsTab({ projectId }: { projectId: string }) {
+    const [isDialogOpen, setIsDialogOpen] = useState(false)
+    const [activeComparisonId, setActiveComparisonId] = useState<string | null>(null)
+    const queryClient = useQueryClient()
+    const { success, error } = useToast()
+
+    const { data, isLoading } = useQuery({
+        queryKey: ['comparisons', projectId],
+        queryFn: () => api.comparisons.list(projectId),
+        enabled: !!projectId,
+    })
+
+    const deleteMutation = useMutation({
+        mutationFn: (id: string) => api.comparisons.delete(id),
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ['comparisons', projectId] })
+            success('Comparison deleted', 'The comparison has been removed.')
+        },
+        onError: () => error('Failed to delete', 'Please try again.'),
+    })
+
+    if (activeComparisonId) {
+        return <ComparisonDetail comparisonId={activeComparisonId} onBack={() => setActiveComparisonId(null)} />
+    }
+
+    if (isLoading) {
+        return (
+            <div className="flex justify-center py-20">
+                <Loader2 className="h-8 w-8 animate-spin text-primary/50" />
+            </div>
+        )
+    }
+
+    const comparisons = data?.data?.items ?? []
+
+    return (
+        <div className="space-y-6">
+            <div className="flex items-center justify-between">
+                <div>
+                    <h2 className="text-xl font-semibold">Comparisons</h2>
+                    <p className="text-sm text-muted-foreground">Compare metrics and answers across two or more evaluations.</p>
+                </div>
+                {comparisons.length > 0 && (
+                    <button
+                        onClick={() => setIsDialogOpen(true)}
+                        className="flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground hover:bg-primary/90 transition-all shadow-md"
+                    >
+                        <Plus className="h-4 w-4" />
+                        New Comparison
+                    </button>
+                )}
+            </div>
+
+            {comparisons.length === 0 ? (
+                <div className="flex flex-col items-center justify-center rounded-xl border border-dashed border-border py-20 bg-card/50">
+                    <div className="rounded-full bg-primary/10 p-5 text-primary">
+                        <GitCompare className="h-10 w-10" />
+                    </div>
+                    <h3 className="mt-5 text-xl font-semibold">No comparisons yet</h3>
+                    <p className="mt-2 max-w-sm text-center text-muted-foreground">
+                        Pick two or more completed evaluations to see how their metrics, costs, and answers stack up.
+                    </p>
+                    <button
+                        onClick={() => setIsDialogOpen(true)}
+                        className="mt-6 flex items-center gap-2 rounded-lg bg-primary px-6 py-2.5 text-sm font-semibold text-primary-foreground hover:bg-primary/90 transition-all shadow-md"
+                    >
+                        <Plus className="h-4 w-4" />
+                        Create First Comparison
+                    </button>
+                </div>
+            ) : (
+                <div className="grid gap-4">
+                    {comparisons.map((c) => {
+                        const memberCount = 1 + (c.compared_evaluation_ids?.length ?? 0)
+                        return (
+                            <div
+                                key={c.id}
+                                className="group relative flex items-center justify-between rounded-xl border border-border bg-card p-4 hover:border-primary/50 hover:shadow-md transition-all cursor-pointer"
+                                onClick={() => setActiveComparisonId(c.id)}
+                            >
+                                <div className="flex items-center gap-4">
+                                    <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10 text-primary">
+                                        <GitCompare className="h-5 w-5" />
+                                    </div>
+                                    <div>
+                                        <p className="font-bold">{c.name || `Comparison #${c.id.slice(0, 8)}`}</p>
+                                        <div className="mt-1 flex items-center gap-3 text-xs font-medium text-muted-foreground">
+                                            <div className="flex items-center gap-1">
+                                                <Calendar className="h-3 w-3" />
+                                                {new Date(c.created_at).toLocaleString()}
+                                            </div>
+                                            <div>{memberCount} evaluations</div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div className="flex items-center gap-2">
+                                    <button
+                                        onClick={(e) => {
+                                            e.stopPropagation()
+                                            deleteMutation.mutate(c.id)
+                                        }}
+                                        className="rounded-lg p-2 text-muted-foreground hover:bg-destructive/10 hover:text-destructive transition-colors"
+                                        title="Delete comparison"
+                                    >
+                                        <Trash2 className="h-4 w-4" />
+                                    </button>
+                                    <div className="rounded-full bg-muted/50 p-2 group-hover:bg-primary group-hover:text-primary-foreground transition-all">
+                                        <ChevronRight className="h-4 w-4" />
+                                    </div>
+                                </div>
+                            </div>
+                        )
+                    })}
+                </div>
+            )}
+
+            <CreateComparisonDialog
+                projectId={projectId}
+                isOpen={isDialogOpen}
+                onClose={() => setIsDialogOpen(false)}
+                onCreated={(id) => {
+                    setIsDialogOpen(false)
+                    queryClient.invalidateQueries({ queryKey: ['comparisons', projectId] })
+                    setActiveComparisonId(id)
+                }}
+            />
+        </div>
+    )
+}

--- a/platform/frontend/src/components/comparisons/ConfigDiff.tsx
+++ b/platform/frontend/src/components/comparisons/ConfigDiff.tsx
@@ -1,0 +1,88 @@
+import { useQueries } from '@tanstack/react-query'
+import { Loader2 } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { api, RunManifest } from '@/api/client'
+import { ComparisonMember } from './compare-utils'
+
+interface ConfigDiffProps {
+    members: ComparisonMember[]
+}
+
+/** Flatten the parts of a manifest we want to diff into a label -> displayable string map. */
+function flattenManifest(manifest: RunManifest | undefined): Record<string, string> {
+    if (!manifest) return {}
+    const out: Record<string, string> = {}
+    const add = (label: string, value: unknown) => {
+        if (value === null || value === undefined) return
+        out[label] = typeof value === 'object' ? JSON.stringify(value) : String(value)
+    }
+    add('Generation model', manifest.generation_model)
+    add('Judge model', manifest.eval_judge_model)
+    add('Evaluator version', manifest.rag_evaluator_version)
+    Object.entries(manifest.rag_config_snapshot ?? {}).forEach(([k, v]) => add(`RAG: ${k}`, v))
+    Object.entries(manifest.kb_version_snapshot ?? {}).forEach(([k, v]) => add(`KB: ${k}`, v))
+    return out
+}
+
+export function ConfigDiff({ members }: ConfigDiffProps) {
+    const queries = useQueries({
+        queries: members.map((m) => ({
+            queryKey: ['manifest', m.id],
+            queryFn: () => api.evaluations.getManifest(m.id).then((r) => r.data),
+            retry: false,
+            staleTime: 5 * 60 * 1000,
+        })),
+    })
+
+    if (queries.some((q) => q.isLoading)) {
+        return (
+            <div className="flex justify-center py-10">
+                <Loader2 className="h-6 w-6 animate-spin text-primary/50" />
+            </div>
+        )
+    }
+
+    const flattened = queries.map((q) => flattenManifest(q.data))
+    const allKeys = Array.from(new Set(flattened.flatMap((f) => Object.keys(f)))).sort()
+
+    if (!allKeys.length) {
+        return <p className="text-sm text-muted-foreground">No run configuration (manifest) is available for these evaluations.</p>
+    }
+
+    return (
+        <div className="overflow-x-auto rounded-xl border border-border">
+            <table className="w-full border-collapse text-sm">
+                <thead>
+                    <tr className="border-b border-border bg-muted/40">
+                        <th className="sticky left-0 z-10 bg-muted/40 px-4 py-3 text-left text-[10px] font-bold uppercase tracking-widest text-muted-foreground">Field</th>
+                        {members.map((m) => (
+                            <th key={m.id} className="min-w-[160px] px-4 py-3 text-left font-bold">
+                                <span className="block truncate max-w-[200px]">{m.label}</span>
+                            </th>
+                        ))}
+                    </tr>
+                </thead>
+                <tbody>
+                    {allKeys.map((key) => {
+                        const values = flattened.map((f) => f[key] ?? null)
+                        const distinct = new Set(values.map((v) => v ?? '∅'))
+                        const differs = distinct.size > 1
+                        return (
+                            <tr key={key} className={cn('border-b border-border/60 last:border-0', differs && 'bg-amber-500/5')}>
+                                <td className="sticky left-0 z-10 bg-card px-4 py-2.5 text-[11px] font-bold uppercase tracking-wider text-muted-foreground whitespace-nowrap">
+                                    {key}
+                                    {differs && <span className="ml-1.5 rounded bg-amber-500/20 px-1 py-0.5 text-[9px] font-bold text-amber-600">diff</span>}
+                                </td>
+                                {values.map((v, i) => (
+                                    <td key={members[i].id} className={cn('px-4 py-2.5 text-xs', differs ? 'font-semibold' : 'text-muted-foreground')}>
+                                        <span className="block max-w-[240px] truncate" title={v ?? '—'}>{v ?? '—'}</span>
+                                    </td>
+                                ))}
+                            </tr>
+                        )
+                    })}
+                </tbody>
+            </table>
+        </div>
+    )
+}

--- a/platform/frontend/src/components/comparisons/CreateComparisonDialog.tsx
+++ b/platform/frontend/src/components/comparisons/CreateComparisonDialog.tsx
@@ -1,0 +1,147 @@
+import { useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { X, Loader2, AlertTriangle, Check } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { api, Evaluation } from '@/api/client'
+
+interface CreateComparisonDialogProps {
+    projectId: string
+    isOpen: boolean
+    onClose: () => void
+    onCreated: (comparisonId: string) => void
+}
+
+export function CreateComparisonDialog({ projectId, isOpen, onClose, onCreated }: CreateComparisonDialogProps) {
+    const [name, setName] = useState('')
+    const [selected, setSelected] = useState<string[]>([])
+    const [isSubmitting, setIsSubmitting] = useState(false)
+    const [error, setError] = useState<string | null>(null)
+
+    const { data, isLoading } = useQuery({
+        queryKey: ['evaluations', projectId],
+        queryFn: () => api.evaluations.list(projectId),
+        enabled: isOpen && !!projectId,
+    })
+
+    if (!isOpen) return null
+
+    const completed = (data?.data?.items ?? []).filter((e) => e.status === 'completed')
+    const selectedEvals = selected.map((id) => completed.find((e) => e.id === id)).filter(Boolean) as Evaluation[]
+    const testSetIds = new Set(selectedEvals.map((e) => e.test_set_id).filter(Boolean))
+    const mixedTestSets = testSetIds.size > 1
+
+    const toggle = (id: string) =>
+        setSelected((prev) => (prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]))
+
+    const handleSubmit = async () => {
+        if (selected.length < 2) return
+        setIsSubmitting(true)
+        setError(null)
+        try {
+            const res = await api.comparisons.create({
+                name: name.trim() || undefined,
+                baseline_evaluation_id: selected[0],
+                compared_evaluation_ids: selected.slice(1),
+            })
+            setName('')
+            setSelected([])
+            onCreated(res.data.id)
+        } catch (err) {
+            console.error('Failed to create comparison:', err)
+            setError('Failed to create comparison. Please try again.')
+        } finally {
+            setIsSubmitting(false)
+        }
+    }
+
+    return (
+        <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+            <div className="absolute inset-0 bg-background/80 backdrop-blur-sm animate-in fade-in" onClick={onClose} />
+            <div className="relative flex max-h-[85vh] w-full max-w-2xl flex-col rounded-xl border border-border bg-card shadow-2xl animate-in zoom-in-95 duration-200">
+                <div className="flex items-center justify-between border-b border-border p-6">
+                    <div>
+                        <h2 className="text-2xl font-bold tracking-tight">New Comparison</h2>
+                        <p className="mt-1 text-sm text-muted-foreground">Select 2 or more completed evaluations. The first selected is the baseline (you can change it later).</p>
+                    </div>
+                    <button onClick={onClose} className="rounded-full p-2 text-muted-foreground hover:bg-muted hover:text-foreground transition-colors">
+                        <X className="h-5 w-5" />
+                    </button>
+                </div>
+
+                <div className="flex-1 space-y-4 overflow-y-auto p-6">
+                    <div className="space-y-2">
+                        <label htmlFor="cmp-name" className="text-sm font-semibold">Name (optional)</label>
+                        <input
+                            id="cmp-name"
+                            value={name}
+                            onChange={(e) => setName(e.target.value)}
+                            placeholder="e.g., Hybrid vs Semantic on Legal KB"
+                            className="w-full rounded-lg border border-input bg-background px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-primary/50"
+                        />
+                    </div>
+
+                    {mixedTestSets && (
+                        <div className="flex items-start gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 p-3 text-xs text-amber-700">
+                            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+                            <span>Selected evaluations use different test sets. Aggregate metrics still compare, but the per-question breakdown will only show overlapping questions.</span>
+                        </div>
+                    )}
+
+                    {isLoading ? (
+                        <div className="flex justify-center py-10"><Loader2 className="h-6 w-6 animate-spin text-primary/50" /></div>
+                    ) : completed.length < 2 ? (
+                        <p className="py-6 text-center text-sm text-muted-foreground">You need at least 2 completed evaluations in this project to create a comparison.</p>
+                    ) : (
+                        <div className="space-y-2">
+                            {completed.map((e) => {
+                                const idx = selected.indexOf(e.id)
+                                const isSelected = idx >= 0
+                                return (
+                                    <button
+                                        key={e.id}
+                                        onClick={() => toggle(e.id)}
+                                        className={cn(
+                                            'flex w-full items-center gap-3 rounded-lg border p-3 text-left transition-all',
+                                            isSelected ? 'border-primary bg-primary/5' : 'border-border hover:border-primary/40',
+                                        )}
+                                    >
+                                        <div className={cn('flex h-5 w-5 shrink-0 items-center justify-center rounded border', isSelected ? 'border-primary bg-primary text-primary-foreground' : 'border-muted-foreground/40')}>
+                                            {isSelected && <Check className="h-3.5 w-3.5" />}
+                                        </div>
+                                        <div className="min-w-0 flex-1">
+                                            <div className="flex items-center gap-2">
+                                                <span className="truncate font-semibold">{e.name || `Evaluation #${e.id.slice(0, 8)}`}</span>
+                                                {idx === 0 && <span className="rounded-full bg-primary/15 px-2 py-0.5 text-[9px] font-bold uppercase text-primary">Baseline</span>}
+                                            </div>
+                                            <span className="text-xs text-muted-foreground">{new Date(e.created_at).toLocaleString()}</span>
+                                        </div>
+                                        <div className="shrink-0 text-right">
+                                            {e.pass_rate !== null && <p className="text-sm font-black tabular-nums">{(e.pass_rate * 100).toFixed(0)}%</p>}
+                                            {e.summary_metrics?.overall_avg !== undefined && <p className="text-[10px] text-muted-foreground">avg {e.summary_metrics.overall_avg.toFixed(2)}</p>}
+                                        </div>
+                                    </button>
+                                )
+                            })}
+                        </div>
+                    )}
+
+                    {error && <p className="text-sm text-destructive">{error}</p>}
+                </div>
+
+                <div className="flex items-center justify-between border-t border-border p-6">
+                    <span className="text-xs text-muted-foreground">{selected.length} selected{selected.length > 10 ? ' (max 10 compared)' : ''}</span>
+                    <div className="flex gap-3">
+                        <button onClick={onClose} className="rounded-lg px-6 py-2.5 text-sm font-semibold hover:bg-muted transition-colors">Cancel</button>
+                        <button
+                            onClick={handleSubmit}
+                            disabled={isSubmitting || selected.length < 2 || selected.length > 11}
+                            className="flex items-center gap-2 rounded-lg bg-primary px-8 py-2.5 text-sm font-semibold text-primary-foreground hover:bg-primary/90 transition-all shadow-md active:scale-95 disabled:opacity-50 disabled:pointer-events-none"
+                        >
+                            {isSubmitting ? <><Loader2 className="h-4 w-4 animate-spin" />Creating...</> : 'Compare'}
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/platform/frontend/src/components/comparisons/MetricMatrix.tsx
+++ b/platform/frontend/src/components/comparisons/MetricMatrix.tsx
@@ -1,0 +1,111 @@
+import { TrendingDown, TrendingUp, Minus, Crown } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { ComparisonMember, METRIC_ROWS, computeDelta, bestMemberIndex } from './compare-utils'
+
+interface MetricMatrixProps {
+    members: ComparisonMember[]
+    baselineId: string
+}
+
+export function MetricMatrix({ members, baselineId }: MetricMatrixProps) {
+    const baseline = members.find((m) => m.id === baselineId) ?? members[0]
+
+    return (
+        <div className="overflow-x-auto rounded-xl border border-border">
+            <table className="w-full border-collapse text-sm">
+                <thead>
+                    <tr className="border-b border-border bg-muted/40">
+                        <th className="sticky left-0 z-10 bg-muted/40 px-4 py-3 text-left text-[10px] font-bold uppercase tracking-widest text-muted-foreground">
+                            Metric
+                        </th>
+                        {members.map((m) => (
+                            <th key={m.id} className="px-4 py-3 text-left min-w-[160px]">
+                                <div className="flex items-center gap-2">
+                                    <span className="font-bold truncate max-w-[180px]">{m.label}</span>
+                                    {m.id === baseline.id && (
+                                        <span className="rounded-full bg-primary/15 px-2 py-0.5 text-[9px] font-bold uppercase tracking-tight text-primary">
+                                            Baseline
+                                        </span>
+                                    )}
+                                </div>
+                                {m.ragConfigName && (
+                                    <p className="text-[10px] font-medium text-muted-foreground truncate max-w-[180px]">{m.ragConfigName}</p>
+                                )}
+                            </th>
+                        ))}
+                    </tr>
+                </thead>
+                <tbody>
+                    {METRIC_ROWS.map((row) => {
+                        const baseVal = row.get(baseline)
+                        const best = bestMemberIndex(members, row)
+                        return (
+                            <tr key={row.key} className="border-b border-border/60 last:border-0 hover:bg-muted/20">
+                                <td className="sticky left-0 z-10 bg-card px-4 py-3 text-[11px] font-bold uppercase tracking-wider text-muted-foreground whitespace-nowrap">
+                                    {row.label}
+                                </td>
+                                {members.map((m, i) => {
+                                    const val = row.get(m)
+                                    const isBaselineCol = m.id === baseline.id
+                                    const delta = isBaselineCol ? null : computeDelta(baseVal, val, row.higherIsBetter)
+                                    const isBest = best === i && members.length > 1
+                                    return (
+                                        <td key={m.id} className="px-4 py-3">
+                                            <div className="flex items-center gap-2">
+                                                <span className={cn('text-base font-black tabular-nums tracking-tight', isBest && 'text-primary')}>
+                                                    {row.format(val)}
+                                                </span>
+                                                {isBest && members.length > 1 && (
+                                                    <Crown className="h-3 w-3 text-primary" />
+                                                )}
+                                            </div>
+                                            {delta && (
+                                                <DeltaBadge
+                                                    absolute={delta.absolute}
+                                                    percentage={delta.percentage}
+                                                    improved={delta.improved}
+                                                    format={row.format}
+                                                />
+                                            )}
+                                        </td>
+                                    )
+                                })}
+                            </tr>
+                        )
+                    })}
+                </tbody>
+            </table>
+        </div>
+    )
+}
+
+function DeltaBadge({
+    absolute,
+    percentage,
+    improved,
+    format,
+}: {
+    absolute: number
+    percentage: number | null
+    improved: boolean | null
+    format: (v: number | null) => string
+}) {
+    const sign = absolute > 0 ? '+' : ''
+    return (
+        <div
+            className={cn(
+                'mt-0.5 flex items-center gap-1 text-[10px] font-bold',
+                improved === true ? 'text-green-500' : improved === false ? 'text-red-500' : 'text-muted-foreground',
+            )}
+        >
+            {improved === true && <TrendingUp className="h-3 w-3" />}
+            {improved === false && <TrendingDown className="h-3 w-3" />}
+            {improved === null && <Minus className="h-3 w-3" />}
+            <span className="tabular-nums">
+                {sign}
+                {format(absolute)}
+                {percentage !== null && ` (${sign}${percentage.toFixed(1)}%)`}
+            </span>
+        </div>
+    )
+}

--- a/platform/frontend/src/components/comparisons/PerQuestionTable.tsx
+++ b/platform/frontend/src/components/comparisons/PerQuestionTable.tsx
@@ -1,0 +1,158 @@
+import { useMemo, useState } from 'react'
+import { ChevronDown, ChevronRight } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { PerQuestionDelta } from '@/api/client'
+import { ComparisonMember } from './compare-utils'
+
+interface PerQuestionTableProps {
+    members: ComparisonMember[]
+    storedBaselineId: string
+    baselineId: string
+    deltas: PerQuestionDelta[]
+}
+
+const SCORE_KEYS = [
+    { key: 'faithfulness', label: 'Faith' },
+    { key: 'relevancy', label: 'Rel' },
+    { key: 'precision', label: 'Prec' },
+    { key: 'recall', label: 'Recall' },
+    { key: 'g_eval', label: 'Correct' },
+]
+
+const num = (v: unknown): number | null => {
+    if (v === null || v === undefined || v === '') return null
+    const n = Number(v)
+    return Number.isFinite(n) ? n : null
+}
+
+function scoresFor(item: PerQuestionDelta, member: ComparisonMember, storedBaselineId: string): Record<string, unknown> | null {
+    if (member.id === storedBaselineId) return item.baseline_result ?? null
+    return item.compared_results?.[member.id] ?? null
+}
+
+function overall(raw: Record<string, unknown> | null): number | null {
+    if (!raw) return null
+    const vals = SCORE_KEYS.map((s) => num(raw[s.key])).filter((v): v is number => v !== null)
+    return vals.length ? vals.reduce((a, b) => a + b, 0) / vals.length : null
+}
+
+function scoreColor(v: number | null): string {
+    if (v === null) return 'bg-muted text-muted-foreground'
+    if (v >= 0.7) return 'bg-green-500/15 text-green-600'
+    if (v >= 0.4) return 'bg-amber-500/15 text-amber-600'
+    return 'bg-red-500/15 text-red-600'
+}
+
+export function PerQuestionTable({ members, storedBaselineId, baselineId, deltas }: PerQuestionTableProps) {
+    const [expanded, setExpanded] = useState<Set<string>>(new Set())
+    const [sortByDelta, setSortByDelta] = useState(true)
+    const [regressionsOnly, setRegressionsOnly] = useState(false)
+
+    const rows = useMemo(() => {
+        const enriched = deltas.map((item) => {
+            const baselineMember = members.find((m) => m.id === baselineId) ?? members[0]
+            const baseOverall = overall(scoresFor(item, baselineMember, storedBaselineId))
+            let maxDrop = 0
+            let maxSpread = 0
+            members.forEach((m) => {
+                const o = overall(scoresFor(item, m, storedBaselineId))
+                if (o !== null && baseOverall !== null) {
+                    maxSpread = Math.max(maxSpread, Math.abs(o - baseOverall))
+                    maxDrop = Math.min(maxDrop, o - baseOverall)
+                }
+            })
+            return { item, maxSpread, hasRegression: maxDrop < -1e-6 }
+        })
+        let filtered = regressionsOnly ? enriched.filter((e) => e.hasRegression) : enriched
+        if (sortByDelta) filtered = [...filtered].sort((a, b) => b.maxSpread - a.maxSpread)
+        return filtered
+    }, [deltas, members, baselineId, storedBaselineId, sortByDelta, regressionsOnly])
+
+    const toggle = (id: string) =>
+        setExpanded((prev) => {
+            const next = new Set(prev)
+            next.has(id) ? next.delete(id) : next.add(id)
+            return next
+        })
+
+    if (!deltas.length) {
+        return <p className="text-sm text-muted-foreground">No per-question data available for this comparison.</p>
+    }
+
+    return (
+        <div className="space-y-3">
+            <div className="flex flex-wrap items-center gap-2">
+                <FilterToggle active={sortByDelta} onClick={() => setSortByDelta((v) => !v)}>Sort by largest difference</FilterToggle>
+                <FilterToggle active={regressionsOnly} onClick={() => setRegressionsOnly((v) => !v)}>Regressions only</FilterToggle>
+                <span className="ml-auto text-xs text-muted-foreground">{rows.length} questions</span>
+            </div>
+
+            <div className="space-y-2">
+                {rows.map(({ item }) => {
+                    const isOpen = expanded.has(item.test_case_id)
+                    return (
+                        <div key={item.test_case_id} className="rounded-lg border border-border bg-card">
+                            <button onClick={() => toggle(item.test_case_id)} className="flex w-full items-center gap-3 p-3 text-left hover:bg-muted/30">
+                                {isOpen ? <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground" /> : <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />}
+                                <span className="flex-1 truncate text-sm font-medium">{item.question || `Test case ${item.test_case_id.slice(0, 8)}`}</span>
+                                <div className="flex shrink-0 items-center gap-1.5">
+                                    {members.map((m) => {
+                                        const o = overall(scoresFor(item, m, storedBaselineId))
+                                        return (
+                                            <span key={m.id} className={cn('rounded px-1.5 py-0.5 text-[10px] font-bold tabular-nums', scoreColor(o))} title={m.label}>
+                                                {o === null ? '—' : o.toFixed(2)}
+                                            </span>
+                                        )
+                                    })}
+                                </div>
+                            </button>
+
+                            {isOpen && (
+                                <div className="grid gap-3 border-t border-border p-3 md:grid-cols-2 lg:grid-cols-3">
+                                    {members.map((m) => {
+                                        const raw = scoresFor(item, m, storedBaselineId)
+                                        return (
+                                            <div key={m.id} className={cn('rounded-lg border p-3', m.id === baselineId ? 'border-primary/40 bg-primary/5' : 'border-border')}>
+                                                <div className="mb-2 flex items-center justify-between">
+                                                    <span className="truncate text-xs font-bold">{m.label}</span>
+                                                    {m.id === baselineId && <span className="text-[9px] font-bold uppercase text-primary">Baseline</span>}
+                                                </div>
+                                                <div className="mb-2 flex flex-wrap gap-1">
+                                                    {SCORE_KEYS.map((s) => {
+                                                        const v = num(raw?.[s.key])
+                                                        return (
+                                                            <span key={s.key} className={cn('rounded px-1.5 py-0.5 text-[10px] font-semibold tabular-nums', scoreColor(v))}>
+                                                                {s.label} {v === null ? '—' : v.toFixed(2)}
+                                                            </span>
+                                                        )
+                                                    })}
+                                                </div>
+                                                <p className="whitespace-pre-wrap text-xs text-muted-foreground line-clamp-6">
+                                                    {(raw?.generated_answer as string) || 'No answer recorded.'}
+                                                </p>
+                                            </div>
+                                        )
+                                    })}
+                                </div>
+                            )}
+                        </div>
+                    )
+                })}
+            </div>
+        </div>
+    )
+}
+
+function FilterToggle({ active, onClick, children }: { active: boolean; onClick: () => void; children: React.ReactNode }) {
+    return (
+        <button
+            onClick={onClick}
+            className={cn(
+                'rounded-full border px-3 py-1 text-xs font-semibold transition-colors',
+                active ? 'border-primary bg-primary/10 text-primary' : 'border-border text-muted-foreground hover:bg-muted',
+            )}
+        >
+            {children}
+        </button>
+    )
+}

--- a/platform/frontend/src/components/comparisons/compare-utils.ts
+++ b/platform/frontend/src/components/comparisons/compare-utils.ts
@@ -1,0 +1,130 @@
+import { AggregateMetrics, EvaluationComparisonResult } from '@/api/client'
+
+/** A single evaluation normalized into a comparable shape (baseline + compared share this). */
+export interface ComparisonMember {
+    id: string
+    label: string
+    ragConfigName?: string | null
+    isStoredBaseline: boolean
+    summary?: Record<string, number | null | undefined> | null
+    cost?: Record<string, number | string | null | undefined> | null
+    performance?: Record<string, number | null | undefined> | null
+    passRate?: number | null
+}
+
+/** Build the ordered member list from a comparison's aggregate metrics. */
+export function buildMembers(agg: AggregateMetrics | null | undefined): ComparisonMember[] {
+    if (!agg) return []
+    const baseline: ComparisonMember = {
+        id: agg.baseline_evaluation_id,
+        label: memberLabel(agg.baseline_evaluation_name, agg.baseline_rag_config_name, agg.baseline_evaluation_id),
+        ragConfigName: agg.baseline_rag_config_name,
+        isStoredBaseline: true,
+        summary: agg.baseline_summary as ComparisonMember['summary'],
+        cost: agg.baseline_cost as ComparisonMember['cost'],
+        performance: agg.baseline_performance as ComparisonMember['performance'],
+        passRate: agg.baseline_pass_rate,
+    }
+    const compared = (agg.comparison_results ?? []).map((r: EvaluationComparisonResult) => ({
+        id: r.evaluation_id,
+        label: memberLabel(r.evaluation_name, r.rag_config_name, r.evaluation_id),
+        ragConfigName: r.rag_config_name,
+        isStoredBaseline: false,
+        summary: r.summary_metrics as ComparisonMember['summary'],
+        cost: r.cost_metrics as ComparisonMember['cost'],
+        performance: r.performance_metrics as ComparisonMember['performance'],
+        passRate: r.pass_rate,
+    }))
+    return [baseline, ...compared]
+}
+
+function memberLabel(name?: string | null, ragConfig?: string | null, id?: string): string {
+    if (name && name.trim()) return name
+    if (ragConfig && ragConfig.trim()) return ragConfig
+    return `#${(id ?? '').slice(0, 8)}`
+}
+
+export interface MetricRow {
+    key: string
+    label: string
+    group: 'quality' | 'cost' | 'performance'
+    isScore: boolean // 0-1 score metric (usable in radar/percent charts)
+    higherIsBetter: boolean
+    get: (m: ComparisonMember) => number | null
+    format: (v: number | null) => string
+}
+
+const toNum = (v: unknown): number | null => {
+    if (v === null || v === undefined || v === '') return null
+    const n = Number(v)
+    return Number.isFinite(n) ? n : null
+}
+
+const fmtScore = (v: number | null) => (v === null ? '—' : v.toFixed(3))
+const fmtPct = (v: number | null) => (v === null ? '—' : `${(v * 100).toFixed(1)}%`)
+const fmtSecs = (v: number | null) => (v === null ? '—' : `${v.toFixed(2)}s`)
+const fmtCost = (v: number | null) => (v === null ? '—' : `$${v.toFixed(4)}`)
+const fmtInt = (v: number | null) => (v === null ? '—' : Math.round(v).toLocaleString())
+
+export const METRIC_ROWS: MetricRow[] = [
+    { key: 'faithfulness', label: 'Faithfulness', group: 'quality', isScore: true, higherIsBetter: true, get: (m) => toNum(m.summary?.faithfulness_avg), format: fmtScore },
+    { key: 'relevancy', label: 'Relevancy', group: 'quality', isScore: true, higherIsBetter: true, get: (m) => toNum(m.summary?.relevancy_avg), format: fmtScore },
+    { key: 'precision', label: 'Precision', group: 'quality', isScore: true, higherIsBetter: true, get: (m) => toNum(m.summary?.precision_avg), format: fmtScore },
+    { key: 'recall', label: 'Recall', group: 'quality', isScore: true, higherIsBetter: true, get: (m) => toNum(m.summary?.recall_avg), format: fmtScore },
+    { key: 'g_eval', label: 'Correctness', group: 'quality', isScore: true, higherIsBetter: true, get: (m) => toNum(m.summary?.g_eval_avg), format: fmtScore },
+    { key: 'overall', label: 'Overall', group: 'quality', isScore: true, higherIsBetter: true, get: (m) => toNum(m.summary?.overall_avg), format: fmtScore },
+    { key: 'pass_rate', label: 'Pass rate', group: 'quality', isScore: false, higherIsBetter: true, get: (m) => toNum(m.passRate), format: fmtPct },
+    { key: 'avg_latency', label: 'Avg latency', group: 'performance', isScore: false, higherIsBetter: false, get: (m) => toNum(m.performance?.avg_latency_seconds), format: fmtSecs },
+    { key: 'p95_latency', label: 'P95 latency', group: 'performance', isScore: false, higherIsBetter: false, get: (m) => toNum(m.performance?.p95_latency_seconds), format: fmtSecs },
+    { key: 'total_cost', label: 'Total cost', group: 'cost', isScore: false, higherIsBetter: false, get: (m) => toNum(m.cost?.total_cost_usd), format: fmtCost },
+    { key: 'avg_cost', label: 'Cost / query', group: 'cost', isScore: false, higherIsBetter: false, get: (m) => toNum(m.cost?.avg_cost_per_query), format: fmtCost },
+    {
+        key: 'total_tokens', label: 'Total tokens', group: 'cost', isScore: false, higherIsBetter: false,
+        get: (m) => {
+            const p = toNum(m.cost?.total_prompt_tokens)
+            const c = toNum(m.cost?.total_completion_tokens)
+            if (p === null && c === null) return null
+            return (p ?? 0) + (c ?? 0)
+        },
+        format: fmtInt,
+    },
+]
+
+export interface Delta {
+    absolute: number
+    percentage: number | null
+    improved: boolean | null
+}
+
+const EPS = 1e-9
+
+/** Direction-aware delta of `value` relative to `baseline`. Null when either side is missing. */
+export function computeDelta(
+    baseline: number | null,
+    value: number | null,
+    higherIsBetter: boolean,
+): Delta | null {
+    if (baseline === null || value === null) return null
+    const absolute = value - baseline
+    const percentage = Math.abs(baseline) > EPS ? (absolute / baseline) * 100 : null
+    let improved: boolean | null = null
+    if (Math.abs(absolute) > EPS) {
+        improved = higherIsBetter ? absolute > 0 : absolute < 0
+    }
+    return { absolute, percentage, improved }
+}
+
+/** Index of the best member for a metric row (for highlighting). Null if none comparable. */
+export function bestMemberIndex(members: ComparisonMember[], row: MetricRow): number | null {
+    let best: number | null = null
+    let bestVal: number | null = null
+    members.forEach((m, i) => {
+        const v = row.get(m)
+        if (v === null) return
+        if (bestVal === null || (row.higherIsBetter ? v > bestVal : v < bestVal)) {
+            bestVal = v
+            best = i
+        }
+    })
+    return best
+}

--- a/platform/frontend/src/components/layout/Layout.tsx
+++ b/platform/frontend/src/components/layout/Layout.tsx
@@ -3,7 +3,6 @@ import {
   LayoutDashboard,
   FolderOpen,
   FlaskConical,
-  GitCompare,
   TrendingUp,
   Settings,
   Database,
@@ -17,7 +16,6 @@ const navigation = [
   { name: 'Indexes', href: '/indexes', icon: Database },
   { name: 'Playground', href: '/playground', icon: Beaker },
   { name: 'Evaluations', href: '/evaluations', icon: FlaskConical },
-  { name: 'Comparisons', href: '/comparisons', icon: GitCompare },
   { name: 'Trends', href: '/trends', icon: TrendingUp },
 ]
 

--- a/platform/frontend/src/pages/ProjectDetail.tsx
+++ b/platform/frontend/src/pages/ProjectDetail.tsx
@@ -15,7 +15,8 @@ import {
     Plus,
     Play,
     ChevronRight,
-    TrendingUp
+    TrendingUp,
+    GitCompare
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { api, KnowledgeBaseCreate, Evaluation, RAGConfig } from '@/api/client'
@@ -32,6 +33,7 @@ import { EvaluationProgress } from '@/components/evaluations/EvaluationProgress'
 import { EvaluationResults } from '@/components/evaluations/EvaluationResults'
 import { TrendChart } from '@/components/trends/TrendChart'
 import { EfficiencyMap } from '@/components/trends/EfficiencyMap'
+import { ComparisonsTab } from '@/components/comparisons/ComparisonsTab'
 import { EditProjectDialog } from '@/components/projects/EditProjectDialog'
 
 function KnowledgeBasesTab({ projectId }: { projectId: string }) {
@@ -574,6 +576,7 @@ const tabs = [
     { id: 'tests', name: 'Test Sets', icon: FileText },
     { id: 'rags', name: 'RAG Configs', icon: Settings2 },
     { id: 'evals', name: 'Evaluations', icon: FlaskConical },
+    { id: 'compare', name: 'Comparisons', icon: GitCompare },
     { id: 'trends', name: 'Trends', icon: TrendingUp },
 ]
 
@@ -724,6 +727,7 @@ export function ProjectDetail() {
                         initialIndexId={initialIndexId}
                     />
                 )}
+                {activeTab === 'compare' && <ComparisonsTab projectId={p.id} />}
                 {activeTab === 'trends' && <TrendsTab projectId={p.id} />}
             </div>
 


### PR DESCRIPTION
Add a project-scoped Comparisons tab to compare two or more evaluations across metrics, charts, per-question results, and run configuration.

Frontend (new components/comparisons/):
- ComparisonsTab: list/create/delete saved comparisons
- CreateComparisonDialog: multi-select completed evals (first = baseline)
- ComparisonDetail: baseline selector + Metrics/Charts/Per-question/Config sub-tabs
- MetricMatrix: metrics x evals with client-side direction-aware deltas
- ComparisonCharts: grouped bars, radar, cost-vs-quality scatter (recharts)
- PerQuestionTable: side-by-side answers/scores, sort/filter by delta
- ConfigDiff: manifest diff with differing rows highlighted
- compare-utils: member normalization, metric defs, delta helpers
- api.comparisons client methods + types
- remove dead global Comparisons nav link (now project-scoped)

Backend (additive, no migration):
- AggregateMetrics: baseline_evaluation_name / baseline_rag_config_name
- per-question deltas: include g_eval score