### PR TITLE
[codex] Add UI review pagination and context fixes

### DIFF
--- a/docs/plans/2026-07-06-ui-review-improvements.md
+++ b/docs/plans/2026-07-06-ui-review-improvements.md
@@ -1,0 +1,97 @@
+# UI Review and Improvement Plan (2026-07-06)
+
+Review of the platform frontend (`platform/frontend/src`) plus the backend list endpoints that back it.
+Findings are ordered by phase; each phase is a small, independently shippable increment.
+
+## Key facts discovered during review
+
+- All backend list endpoints share `Pagination` (`platform/backend/app/api/deps.py`): default `limit=20`, max `100`.
+  Most frontend list calls pass no params, so **every list silently truncates at 20 items** with no
+  pagination UI (evaluations, KBs, test sets, RAG configs, comparisons).
+- `list_evaluations` (`platform/backend/app/api/evaluations.py:631`) calls `_evaluation_to_response(e)`
+  without `result_count`, so the Evaluations tab shows **"0 results" on every row**, and the
+  partial-results logic in `EvaluationsTab` (which reads `result_count` from the list) never triggers.
+- `EvaluationResults.tsx:56` has `const [page] = useState(1)` — page is hardcoded, only the first 50
+  results are ever shown, and the search box filters only that first page.
+- KB detail embeds ALL documents in `GET /knowledge-bases/{kb_id}` (no paginated documents endpoint
+  exists); test set detail likewise embeds all test cases.
+- `EvaluationsTab` in `ProjectDetail.tsx` contains a dead in-tab detail view: `setActiveEvaluationId`
+  is only ever called with `null` (rows navigate to the `/projects/:id/evaluations/:id` route instead).
+- Deleting a document in `KBDetail.tsx` has **no confirmation** (every other destructive action uses
+  `window.confirm`).
+- The evaluation list response has `test_set_id` / `knowledge_base_index_id` but no names, and the
+  index list response has `project_id` but no `project_name` — so neither list can display
+  human-readable context.
+- `Indexes.tsx` (global page) is stylistically inconsistent: raw `useState`/`useEffect` instead of
+  react-query, hardcoded `gray-*`/`bg-white` colors instead of design tokens, search is client-side
+  over a max of 50 fetched rows, and fetch errors render as "No indexes found".
+
+## Phase 1 — Bug fixes (small, do first)
+
+1. **`result_count` in evaluations list** (backend): in `list_evaluations`, compute per-evaluation
+   result counts (single grouped `select(EvaluationResult.evaluation_id, func.count())` over the page's
+   ids) and pass them to `_evaluation_to_response`.
+2. **Remove dead code**: delete the `activeEvaluationId` branch in `EvaluationsTab`
+   (`ProjectDetail.tsx` ~lines 594-659).
+3. **Confirm document delete** in `KBDetail.tsx` (match the existing `confirm()` pattern).
+
+## Phase 2 — Evaluations tab: context + filters (user finding 2)
+
+Backend (`evaluations.py`, `schemas/evaluation.py`):
+- Add optional denormalized fields to `EvaluationResponse`: `test_set_name`, `index_name`,
+  `rag_config_name`, `rag_type` (join `TestSet` and `KnowledgeBaseIndex`; rag info comes from the
+  index's `rag_config` / `config_snapshot`). Populate in `list_evaluations` and `get_evaluation`.
+- Add filter query params to `list_evaluations`: `test_set_id`, `knowledge_base_index_id`,
+  `rag_config_id` (via join on index), keep `status`. Apply to both the page query and count query.
+
+Frontend (`ProjectDetail.tsx` EvaluationsTab, `api/client.ts`):
+- Row chips: test set name, index name, RAG type, plus a "Baseline" badge when `is_baseline`.
+- Filter bar above the list: dropdowns for test set / RAG config / index / status, driven by the
+  already-fetched project test sets, configs, and indexes; filters go into the URL search params
+  (same pattern as `Indexes.tsx`) and are passed to the API.
+
+## Phase 3 — Pagination (user finding 3)
+
+1. **Shared component**: `components/ui/PaginationFooter.tsx` — "Showing X–Y of Z", prev/next
+   (all `PaginatedList` responses already return `total`, `offset`, `limit`).
+2. **Evaluations tab**: page state + `PaginationFooter` (combined with Phase 2 filters).
+3. **Evaluation results** (`EvaluationResults.tsx`): wire the existing `page` state to real controls.
+   Optionally add a `search` query param to `GET /evaluations/{id}/results` (ILIKE on question /
+   answers via the joined test case) so search spans all pages instead of the loaded page.
+   Note: `DifficultyChart` currently aggregates the loaded page only — acceptable short-term; the
+   proper fix is a small server-side per-difficulty aggregate endpoint (optional, later).
+4. **KB documents**: new endpoint `GET /knowledge-bases/{kb_id}/documents` (Pagination + optional
+   `search` on filename). `KBDetail.tsx` switches to it with `PaginationFooter` + a search box.
+   Then stop embedding `documents` in the KB detail response (check other consumers first);
+   the KB response already carries `document_count`.
+5. **Test cases**: same pattern — `GET /test-sets/{id}/cases` paginated; `TestSetDetail.tsx` uses it.
+   Lower priority (test sets are typically ~50-200 cases, but generation can produce more).
+
+## Phase 4 — Global Indexes page (user finding 1)
+
+Verdict: the page is useful as a cross-project "build status" console (and it is the only place to
+watch builds across projects), but as-is it doesn't show which project an index belongs to, which is
+what makes it feel wrong.
+
+- Backend: add `project_name` to the index list response (it already denormalizes
+  `knowledge_base_name` and `rag_config_name`).
+- Frontend `Indexes.tsx`:
+  - Show project name on each card (link to the project) and add a project filter dropdown.
+  - Migrate to react-query + theme design tokens (remove `gray-*`/`bg-white`).
+  - Proper error state (currently errors look like an empty list).
+  - Pagination via `PaginationFooter` instead of the fixed `limit: 50`.
+- Alternative considered: remove the sidebar entry entirely (project tab + Playground cover most
+  uses). Not recommended — cheap to fix, and it's the only cross-project build monitor.
+
+## Phase 5 — Polish (optional, as time allows)
+
+- Surface API errors as toasts (the axios interceptor only `console.error`s today).
+- Replace scattered `window.confirm` with a shared `ConfirmDialog` for visual consistency.
+- Pass-rate color scale: add a red band for low values (currently green >= 70%, amber otherwise).
+
+## Verification
+
+- Backend: run the API and hit endpoints directly (pytest hangs on this machine — use
+  `dev_server.py` + curl or direct imports).
+- Frontend: `npm run lint` + `npx tsc --noEmit` in `platform/frontend`, then manual walkthrough:
+  project with >20 evaluations, KB with >100 documents, evaluation with >50 results.

--- a/platform/backend/alembic/env.py
+++ b/platform/backend/alembic/env.py
@@ -86,10 +86,11 @@ async def run_async_migrations() -> None:
         connect_args=connect_args,
     )
 
-    async with connectable.connect() as connection:
-        await connection.run_sync(do_run_migrations)
-
-    await connectable.dispose()
+    try:
+        async with connectable.connect() as connection:
+            await connection.run_sync(do_run_migrations)
+    finally:
+        await connectable.dispose()
 
 
 def run_migrations_online() -> None:

--- a/platform/backend/app/api/evaluations.py
+++ b/platform/backend/app/api/evaluations.py
@@ -6,7 +6,7 @@ from typing import Any, AsyncGenerator
 from uuid import UUID
 
 from fastapi import APIRouter, BackgroundTasks, HTTPException, Query, status
-from sqlalchemy import func, select
+from sqlalchemy import func, or_, select
 from sqlalchemy.orm import selectinload
 from sse_starlette.sse import EventSourceResponse
 
@@ -15,6 +15,7 @@ from app.models.evaluation import Evaluation
 from app.models.evaluation_result import EvaluationResult
 from app.models.knowledge_base_index import KnowledgeBaseIndex
 from app.models.run_manifest import RunManifest
+from app.models.test_case import TestCase
 from app.models.test_set import TestSet
 from app.schemas.evaluation import (
     CostMetrics,
@@ -46,7 +47,7 @@ async def _get_evaluation_or_404(db: DbSession, evaluation_id: UUID) -> Evaluati
         .where(Evaluation.id == evaluation_id)
         .options(
             # selectinload(Evaluation.rag_config), # Removed as relationship removed
-            selectinload(Evaluation.index),  # Load index
+            selectinload(Evaluation.index).selectinload(KnowledgeBaseIndex.rag_config),
             selectinload(Evaluation.test_set).selectinload(TestSet.test_cases),
         )
     )
@@ -62,6 +63,13 @@ async def _get_evaluation_or_404(db: DbSession, evaluation_id: UUID) -> Evaluati
 
 def _evaluation_to_response(eval_model: Evaluation, result_count: int = 0) -> EvaluationResponse:
     """Convert Evaluation model to EvaluationResponse schema."""
+    index = eval_model.__dict__.get("index")
+    test_set = eval_model.__dict__.get("test_set")
+    rag_config = index.__dict__.get("rag_config") if index else None
+    config_snapshot = index.config_snapshot if index and isinstance(index.config_snapshot, dict) else {}
+    rag_type = rag_config.rag_type if rag_config else config_snapshot.get("rag_type")
+    rag_config_id = eval_model.rag_config_id or (index.rag_config_id if index else None)
+
     return EvaluationResponse(
         id=eval_model.id,
         name=eval_model.name,
@@ -70,7 +78,12 @@ def _evaluation_to_response(eval_model: Evaluation, result_count: int = 0) -> Ev
         knowledge_base_index_id=eval_model.knowledge_base_index_id,
         kb_version_id=eval_model.kb_version_id,
         test_set_id=eval_model.test_set_id,
+        rag_config_id=rag_config_id,
         run_manifest_id=eval_model.run_manifest_id,
+        test_set_name=test_set.name if test_set else None,
+        index_name=index.name if index else None,
+        rag_config_name=rag_config.name if rag_config else None,
+        rag_type=rag_type,
         status=eval_model.status,
         started_at=eval_model.started_at,
         completed_at=eval_model.completed_at,
@@ -273,6 +286,7 @@ async def get_evaluation_results(
     db: DbSession,
     evaluation_id: UUID,
     pagination: Pagination,
+    search: str | None = Query(default=None),
 ) -> EvaluationResultList:
     """Get paginated results for an evaluation."""
     # Verify evaluation exists
@@ -284,11 +298,22 @@ async def get_evaluation_results(
         .where(EvaluationResult.evaluation_id == evaluation_id)
         .options(selectinload(EvaluationResult.test_case))
     )
-
-    # Get total count
     count_query = select(func.count(EvaluationResult.id)).where(
         EvaluationResult.evaluation_id == evaluation_id
     )
+
+    search_term = search.strip() if search else None
+    if search_term:
+        pattern = f"%{search_term}%"
+        search_filter = or_(
+            EvaluationResult.generated_answer.ilike(pattern),
+            TestCase.question.ilike(pattern),
+            TestCase.expected_answer.ilike(pattern),
+        )
+        query = query.outerjoin(EvaluationResult.test_case).where(search_filter)
+        count_query = count_query.outerjoin(EvaluationResult.test_case).where(search_filter)
+
+    # Get total count
     total_result = await db.execute(count_query)
     total = total_result.scalar() or 0
 
@@ -633,18 +658,39 @@ async def list_evaluations(
     project_id: UUID,
     pagination: Pagination,
     status: str | None = Query(default=None),
+    test_set_id: UUID | None = Query(default=None),
+    knowledge_base_index_id: UUID | None = Query(default=None),
+    rag_config_id: UUID | None = Query(default=None),
 ) -> EvaluationList:
     """List all evaluations in a project."""
     # Build query
-    query = select(Evaluation).where(Evaluation.project_id == project_id)
+    query = (
+        select(Evaluation)
+        .where(Evaluation.project_id == project_id)
+        .options(
+            selectinload(Evaluation.index).selectinload(KnowledgeBaseIndex.rag_config),
+            selectinload(Evaluation.test_set),
+        )
+    )
+    count_query = select(func.count(Evaluation.id)).where(Evaluation.project_id == project_id)
 
     if status:
         query = query.where(Evaluation.status == status)
-
-    # Get total count
-    count_query = select(func.count(Evaluation.id)).where(Evaluation.project_id == project_id)
-    if status:
         count_query = count_query.where(Evaluation.status == status)
+
+    if test_set_id:
+        query = query.where(Evaluation.test_set_id == test_set_id)
+        count_query = count_query.where(Evaluation.test_set_id == test_set_id)
+
+    if knowledge_base_index_id:
+        query = query.where(Evaluation.knowledge_base_index_id == knowledge_base_index_id)
+        count_query = count_query.where(Evaluation.knowledge_base_index_id == knowledge_base_index_id)
+
+    if rag_config_id:
+        query = query.join(Evaluation.index).where(KnowledgeBaseIndex.rag_config_id == rag_config_id)
+        count_query = count_query.join(Evaluation.index).where(
+            KnowledgeBaseIndex.rag_config_id == rag_config_id
+        )
 
     total_result = await db.execute(count_query)
     total = total_result.scalar() or 0
@@ -656,9 +702,22 @@ async def list_evaluations(
     # Execute query
     result = await db.execute(query)
     evaluations = result.scalars().all()
+    evaluation_ids = [evaluation.id for evaluation in evaluations]
+    result_counts: dict[UUID, int] = {}
+    if evaluation_ids:
+        result_count_query = (
+            select(EvaluationResult.evaluation_id, func.count(EvaluationResult.id))
+            .where(EvaluationResult.evaluation_id.in_(evaluation_ids))
+            .group_by(EvaluationResult.evaluation_id)
+        )
+        result_count_rows = (await db.execute(result_count_query)).all()
+        result_counts = {evaluation_id: count for evaluation_id, count in result_count_rows}
 
     return EvaluationList(
-        items=[_evaluation_to_response(e) for e in evaluations],
+        items=[
+            _evaluation_to_response(e, result_count=result_counts.get(e.id, 0))
+            for e in evaluations
+        ],
         total=total,
         offset=pagination.offset,
         limit=pagination.limit,

--- a/platform/backend/app/api/indexes.py
+++ b/platform/backend/app/api/indexes.py
@@ -65,6 +65,9 @@ def _index_to_response(index: KnowledgeBaseIndex) -> KnowledgeBaseIndexResponse:
         knowledge_base_name=index.knowledge_base.name if index.knowledge_base else None,
         rag_config_name=index.rag_config.name if index.rag_config else None,
         project_id=index.knowledge_base.project_id if index.knowledge_base else None,
+        project_name=index.knowledge_base.project.name
+        if index.knowledge_base and index.knowledge_base.project
+        else None,
     )
 
 
@@ -83,7 +86,7 @@ async def list_indexes(
 ) -> KnowledgeBaseIndexList:
     """List all indexes."""
     query = select(KnowledgeBaseIndex).options(
-        selectinload(KnowledgeBaseIndex.knowledge_base),
+        selectinload(KnowledgeBaseIndex.knowledge_base).selectinload(KnowledgeBase.project),
         selectinload(KnowledgeBaseIndex.rag_config),
     )
 
@@ -161,7 +164,7 @@ async def create_index(
         select(KnowledgeBaseIndex)
         .where(KnowledgeBaseIndex.id == index.id)
         .options(
-            selectinload(KnowledgeBaseIndex.knowledge_base),
+            selectinload(KnowledgeBaseIndex.knowledge_base).selectinload(KnowledgeBase.project),
             selectinload(KnowledgeBaseIndex.rag_config),
         )
     )
@@ -186,7 +189,7 @@ async def get_index(
         select(KnowledgeBaseIndex)
         .where(KnowledgeBaseIndex.id == index_id)
         .options(
-            selectinload(KnowledgeBaseIndex.knowledge_base),
+            selectinload(KnowledgeBaseIndex.knowledge_base).selectinload(KnowledgeBase.project),
             selectinload(KnowledgeBaseIndex.rag_config),
         )
     )
@@ -311,7 +314,7 @@ async def archive_index(
         select(KnowledgeBaseIndex)
         .where(KnowledgeBaseIndex.id == index_id)
         .options(
-            selectinload(KnowledgeBaseIndex.knowledge_base),
+            selectinload(KnowledgeBaseIndex.knowledge_base).selectinload(KnowledgeBase.project),
             selectinload(KnowledgeBaseIndex.rag_config),
         )
     )

--- a/platform/backend/app/api/knowledge_bases.py
+++ b/platform/backend/app/api/knowledge_bases.py
@@ -14,6 +14,7 @@ from app.models.knowledge_base import KnowledgeBase
 from app.models.knowledge_base_version import KnowledgeBaseVersion
 from app.models.project import Project
 from app.schemas.knowledge_base import (
+    DocumentList,
     DocumentResponse,
     DocumentUploadResponse,
     KnowledgeBaseCreate,
@@ -487,6 +488,47 @@ async def upload_documents(
         uploaded=uploaded,
         failed=failed,
         total_size_bytes=total_size,
+    )
+
+
+@router.get(
+    "/knowledge-bases/{kb_id}/documents",
+    response_model=DocumentList,
+    summary="List knowledge base documents",
+    description="Retrieve paginated documents for a knowledge base.",
+    responses={404: {"description": "Knowledge base not found"}},
+)
+async def list_documents(
+    db: DbSession,
+    kb_id: UUID,
+    pagination: Pagination,
+    search: str | None = None,
+) -> DocumentList:
+    """List documents in a knowledge base."""
+    exists_result = await db.execute(select(KnowledgeBase.id).where(KnowledgeBase.id == kb_id))
+    if not exists_result.scalar_one_or_none():
+        raise NotFoundError(detail=f"Knowledge base with id {kb_id} not found")
+
+    query = select(Document).where(Document.knowledge_base_id == kb_id)
+    count_query = select(func.count(Document.id)).where(Document.knowledge_base_id == kb_id)
+
+    search_term = search.strip() if search else None
+    if search_term:
+        pattern = f"%{search_term}%"
+        query = query.where(Document.filename.ilike(pattern))
+        count_query = count_query.where(Document.filename.ilike(pattern))
+
+    total = (await db.execute(count_query)).scalar() or 0
+    result = await db.execute(
+        query.order_by(Document.created_at.desc()).offset(pagination.offset).limit(pagination.limit)
+    )
+    documents = result.scalars().all()
+
+    return DocumentList(
+        items=[_document_to_response(doc) for doc in documents],
+        total=total,
+        offset=pagination.offset,
+        limit=pagination.limit,
     )
 
 

--- a/platform/backend/app/schemas/evaluation.py
+++ b/platform/backend/app/schemas/evaluation.py
@@ -163,9 +163,12 @@ class EvaluationResponse(EvaluationBase, BaseResponseSchema):
     )
     kb_version_id: UUID | None = Field(default=None, description="KB version ID")
     test_set_id: UUID | None = Field(default=None, description="Test set ID")
-    # rag_config_id is deprecated/removed, but we might keep it for legacy if needed.
-    # We'll remove it to align with new plan.
+    rag_config_id: UUID | None = Field(default=None, description="RAG config ID")
     run_manifest_id: UUID | None = Field(default=None, description="Run manifest ID")
+    test_set_name: str | None = Field(default=None, description="Test set name")
+    index_name: str | None = Field(default=None, description="Index name")
+    rag_config_name: str | None = Field(default=None, description="RAG config name")
+    rag_type: str | None = Field(default=None, description="RAG implementation type")
 
     status: str = Field(description="Evaluation status")
     started_at: datetime | None = Field(default=None, description="Start time")

--- a/platform/backend/app/schemas/knowledge_base.py
+++ b/platform/backend/app/schemas/knowledge_base.py
@@ -115,6 +115,12 @@ class KnowledgeBaseList(PaginatedResponse):
     items: list[KnowledgeBaseResponse]
 
 
+class DocumentList(PaginatedResponse):
+    """Paginated list of knowledge base documents."""
+
+    items: list[DocumentResponse]
+
+
 class KnowledgeBaseIndexRequest(BaseSchema):
     """Schema for indexing request."""
 

--- a/platform/backend/app/schemas/knowledge_base_index.py
+++ b/platform/backend/app/schemas/knowledge_base_index.py
@@ -45,6 +45,7 @@ class KnowledgeBaseIndexResponse(BaseModel):
     knowledge_base_name: str | None = None
     rag_config_name: str | None = None
     project_id: UUID | None = None
+    project_name: str | None = None
 
 
 class KnowledgeBaseIndexList(BaseModel):

--- a/platform/frontend/src/api/client.ts
+++ b/platform/frontend/src/api/client.ts
@@ -208,6 +208,7 @@ export interface KnowledgeBaseIndex {
   knowledge_base_name?: string
   rag_config_name?: string
   project_id?: string
+  project_name?: string
 }
 
 export interface KnowledgeBaseIndexCreate {
@@ -308,6 +309,10 @@ export interface Evaluation {
   knowledge_base_index_id: string | null
   test_set_id: string | null
   rag_config_id: string | null
+  test_set_name: string | null
+  index_name: string | null
+  rag_config_name: string | null
+  rag_type: string | null
   status: 'pending' | 'running' | 'completed' | 'failed' | 'cancelled' | 'paused'
   started_at: string | null
   completed_at: string | null
@@ -747,6 +752,8 @@ export const api = {
     },
     deleteDocument: (kbId: string, docId: string) =>
       apiClient.delete(`/knowledge-bases/${kbId}/documents/${docId}`),
+    listDocuments: (id: string, params?: { limit?: number; offset?: number; search?: string }) =>
+      apiClient.get<PaginatedList<Document>>(`/knowledge-bases/${id}/documents`, { params }),
     getStatus: (id: string) => apiClient.get(`/knowledge-bases/${id}/status`),
     // index method is deprecated/removed in favor of api.indexes.create
   },
@@ -817,11 +824,18 @@ export const api = {
     getLLMProviders: () => apiClient.get<LLMProviderInfo[]>('/llm-providers'),
   },
   evaluations: {
-    list: (projectId: string, params?: { limit?: number; offset?: number }) =>
+    list: (projectId: string, params?: {
+      limit?: number
+      offset?: number
+      status?: string
+      test_set_id?: string
+      knowledge_base_index_id?: string
+      rag_config_id?: string
+    }) =>
       apiClient.get<PaginatedList<Evaluation>>(`/projects/${projectId}/evaluations`, { params }),
     get: (id: string) => apiClient.get<Evaluation>(`/evaluations/${id}`),
     create: (data: EvaluationCreate) => apiClient.post<Evaluation>('/evaluations', data),
-    getResults: (id: string, params?: { limit?: number; offset?: number }) =>
+    getResults: (id: string, params?: { limit?: number; offset?: number; search?: string }) =>
       apiClient.get<PaginatedList<EvaluationResult>>(`/evaluations/${id}/results`, { params }),
     cancel: (id: string) => apiClient.post(`/evaluations/${id}/cancel`),
     pause: (id: string) => apiClient.post(`/evaluations/${id}/pause`),

--- a/platform/frontend/src/components/evaluations/EvaluationResults.tsx
+++ b/platform/frontend/src/components/evaluations/EvaluationResults.tsx
@@ -19,6 +19,7 @@ import { RetrievalTraceViewer } from './RetrievalTraceViewer'
 import { ManifestViewer } from './ManifestViewer'
 import { BaselineComparison } from './BaselineComparison'
 import { DifficultyChart } from './DifficultyChart'
+import { PaginationFooter } from '@/components/ui/PaginationFooter'
 
 interface EvaluationResultsProps {
     evaluationId: string
@@ -53,7 +54,7 @@ const METRIC_DEFINITIONS: MetricDefinition[] = [
 ];
 
 export function EvaluationResults({ evaluationId, onBack }: EvaluationResultsProps) {
-    const [page] = useState(1)
+    const [page, setPage] = useState(1)
     const [search, setSearch] = useState('')
     const [expandedResultId, setExpandedResultId] = useState<string | null>(null)
     const [activeDetailTab, setActiveDetailTab] = useState<'overview' | 'trace'>('overview')
@@ -61,6 +62,7 @@ export function EvaluationResults({ evaluationId, onBack }: EvaluationResultsPro
     const [isSettingBaseline, setIsSettingBaseline] = useState(false)
     const [baselineReason, setBaselineReason] = useState('')
     const [committedSearch, setCommittedSearch] = useState('')
+    const pageSize = 50
 
     const { data: evaluation } = useQuery({
         queryKey: ['evaluation', evaluationId],
@@ -68,8 +70,12 @@ export function EvaluationResults({ evaluationId, onBack }: EvaluationResultsPro
     })
 
     const { data: results, isLoading } = useQuery({
-        queryKey: ['evaluation-results', evaluationId, page],
-        queryFn: () => api.evaluations.getResults(evaluationId, { limit: 50, offset: (page - 1) * 50 }),
+        queryKey: ['evaluation-results', evaluationId, page, committedSearch],
+        queryFn: () => api.evaluations.getResults(evaluationId, {
+            limit: pageSize,
+            offset: (page - 1) * pageSize,
+            search: committedSearch || undefined,
+        }),
     })
 
     const { data: baseline, refetch: refetchBaseline } = useQuery({
@@ -93,20 +99,8 @@ export function EvaluationResults({ evaluationId, onBack }: EvaluationResultsPro
 
     const filteredItems = useMemo(() => {
         const items = results?.data?.items || []
-        const term = committedSearch.trim().toLowerCase()
-        if (!term) return items
-        return items.filter((result) => {
-            const haystack = [
-                result.question,
-                result.expected_answer,
-                result.generated_answer,
-            ]
-                .filter(Boolean)
-                .join(' ')
-                .toLowerCase()
-            return haystack.includes(term)
-        })
-    }, [results?.data?.items, committedSearch])
+        return items
+    }, [results?.data?.items])
     const selectedMetricIds = evaluation?.data?.metric_config?.metrics || ['faithfulness', 'relevancy', 'precision', 'recall', 'g_eval'];
     const activeMetrics = METRIC_DEFINITIONS.filter(m => selectedMetricIds.includes(m.id));
     const correctnessMetric = activeMetrics.find(m => m.id === 'g_eval');
@@ -315,6 +309,7 @@ export function EvaluationResults({ evaluationId, onBack }: EvaluationResultsPro
                                 onKeyDown={(e) => {
                                     if (e.key === 'Enter') {
                                         setCommittedSearch(search)
+                                        setPage(1)
                                     }
                                 }}
                                 className="h-10 w-full rounded-lg border border-input bg-background pl-9 pr-4 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
@@ -456,10 +451,17 @@ export function EvaluationResults({ evaluationId, onBack }: EvaluationResultsPro
 
                         {filteredItems.length === 0 && (
                             <div className="py-20 text-center text-muted-foreground">
-                                No results found matching your search.
+                                {committedSearch ? 'No results found matching your search.' : 'No results have been saved yet.'}
                             </div>
                         )}
                     </div>
+                    <PaginationFooter
+                        total={results?.data.total ?? 0}
+                        offset={results?.data.offset ?? (page - 1) * pageSize}
+                        limit={results?.data.limit ?? pageSize}
+                        onPageChange={(offset) => setPage(Math.floor(offset / pageSize) + 1)}
+                        isLoading={isLoading}
+                    />
                 </>
             ) : (
                 <ManifestViewer evaluationId={evaluationId} />

--- a/platform/frontend/src/components/indexes/IndexCard.tsx
+++ b/platform/frontend/src/components/indexes/IndexCard.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom'
 import { KnowledgeBaseIndex, api } from '../../api/client'
-import { Database, Trash2, Play, HardDrive, Cpu, FileText } from 'lucide-react'
+import { Database, Trash2, Play, HardDrive, Cpu, FileText, FolderKanban } from 'lucide-react'
 import { useState } from 'react'
 
 interface IndexCardProps {
@@ -48,13 +48,13 @@ export function IndexCard({ index, onDelete, onRunEvaluation }: IndexCardProps) 
   }
 
   return (
-    <div className="bg-white border rounded-lg p-4 hover:shadow-md transition-shadow">
+    <div className="rounded-lg border border-border bg-card p-4 transition-shadow hover:shadow-md">
       <div className="flex justify-between items-start mb-2">
         <div className="flex-1 min-w-0 mr-4">
-          <Link to={`/indexes/${index.id}`} className="font-medium text-lg text-blue-600 hover:underline truncate block">
+          <Link to={`/indexes/${index.id}`} className="block truncate text-lg font-medium text-primary hover:underline">
             {index.name}
           </Link>
-          <p className="text-sm text-gray-500 line-clamp-2">{index.description || 'No description'}</p>
+          <p className="line-clamp-2 text-sm text-muted-foreground">{index.description || 'No description'}</p>
         </div>
         <div className="flex space-x-2 flex-shrink-0">
           {index.status === 'ready' && onRunEvaluation && (
@@ -64,7 +64,7 @@ export function IndexCard({ index, onDelete, onRunEvaluation }: IndexCardProps) 
                 e.stopPropagation()
                 onRunEvaluation()
               }}
-              className="p-1 text-gray-400 hover:text-green-600"
+              className="p-1 text-muted-foreground hover:text-green-600"
               title="Run Evaluation"
             >
               <Play className="h-5 w-5" />
@@ -73,7 +73,7 @@ export function IndexCard({ index, onDelete, onRunEvaluation }: IndexCardProps) 
           <button
             onClick={handleDelete}
             disabled={isDeleting}
-            className="p-1 text-gray-400 hover:text-red-600 disabled:opacity-50"
+            className="p-1 text-muted-foreground hover:text-destructive disabled:opacity-50"
             title="Delete Index"
           >
             <Trash2 className="h-5 w-5" />
@@ -82,33 +82,44 @@ export function IndexCard({ index, onDelete, onRunEvaluation }: IndexCardProps) 
       </div>
 
       <div className="grid grid-cols-2 gap-4 text-sm mt-4">
-        <div className="flex items-center text-gray-600 min-w-0">
+        {index.project_name && index.project_id && (
+          <Link
+            to={`/projects/${index.project_id}`}
+            className="col-span-2 flex min-w-0 items-center text-muted-foreground hover:text-primary"
+          >
+            <FolderKanban className="h-4 w-4 mr-2 flex-shrink-0" />
+            <span className="truncate" title={index.project_name}>
+              Project: {index.project_name}
+            </span>
+          </Link>
+        )}
+        <div className="flex items-center text-muted-foreground min-w-0">
           <Database className="h-4 w-4 mr-2 flex-shrink-0" />
           <span className="truncate" title={index.knowledge_base_name}>
             KB: {index.knowledge_base_name}
           </span>
         </div>
-        <div className="flex items-center text-gray-600 min-w-0">
+        <div className="flex items-center text-muted-foreground min-w-0">
           <Cpu className="h-4 w-4 mr-2 flex-shrink-0" />
           <span className="truncate" title={index.rag_config_name}>
             RAG: {index.rag_config_name}
           </span>
         </div>
-        <div className="flex items-center text-gray-600">
+        <div className="flex items-center text-muted-foreground">
           <HardDrive className="h-4 w-4 mr-2 flex-shrink-0" />
           <span>{index.storage_type}</span>
         </div>
-        <div className="flex items-center text-gray-600">
+        <div className="flex items-center text-muted-foreground">
           <FileText className="h-4 w-4 mr-2 flex-shrink-0" />
           <span>{index.chunk_count} chunks</span>
         </div>
       </div>
 
-      <div className="mt-4 pt-3 border-t flex justify-between items-center text-xs text-gray-500">
-        <span className={`px-2 py-0.5 rounded-full ${index.status === 'ready' ? 'bg-green-100 text-green-800' :
-          index.status === 'building' ? 'bg-blue-100 text-blue-800' :
-            index.status === 'failed' ? 'bg-red-100 text-red-800' :
-              'bg-gray-100 text-gray-800'
+      <div className="mt-4 pt-3 border-t border-border flex justify-between items-center text-xs text-muted-foreground">
+        <span className={`px-2 py-0.5 rounded-full ${index.status === 'ready' ? 'bg-green-500/10 text-green-700' :
+          index.status === 'building' ? 'bg-blue-500/10 text-blue-700' :
+            index.status === 'failed' ? 'bg-red-500/10 text-red-700' :
+              'bg-muted text-muted-foreground'
           }`}>
           {index.status.charAt(0).toUpperCase() + index.status.slice(1)}
         </span>

--- a/platform/frontend/src/components/ui/PaginationFooter.tsx
+++ b/platform/frontend/src/components/ui/PaginationFooter.tsx
@@ -1,0 +1,50 @@
+import { ChevronLeft, ChevronRight } from 'lucide-react'
+
+interface PaginationFooterProps {
+  total: number
+  offset: number
+  limit: number
+  onPageChange: (offset: number) => void
+  isLoading?: boolean
+}
+
+export function PaginationFooter({
+  total,
+  offset,
+  limit,
+  onPageChange,
+  isLoading = false,
+}: PaginationFooterProps) {
+  const start = total === 0 ? 0 : offset + 1
+  const end = Math.min(offset + limit, total)
+  const hasPrevious = offset > 0
+  const hasNext = offset + limit < total
+
+  return (
+    <div className="flex flex-col gap-3 border-t border-border px-4 py-3 text-sm text-muted-foreground sm:flex-row sm:items-center sm:justify-between">
+      <span>
+        Showing {start}-{end} of {total}
+      </span>
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={() => onPageChange(Math.max(0, offset - limit))}
+          disabled={!hasPrevious || isLoading}
+          className="inline-flex h-9 items-center gap-1 rounded-md border border-border bg-background px-3 text-sm font-medium text-foreground transition-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          <ChevronLeft className="h-4 w-4" />
+          Previous
+        </button>
+        <button
+          type="button"
+          onClick={() => onPageChange(offset + limit)}
+          disabled={!hasNext || isLoading}
+          className="inline-flex h-9 items-center gap-1 rounded-md border border-border bg-background px-3 text-sm font-medium text-foreground transition-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          Next
+          <ChevronRight className="h-4 w-4" />
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/platform/frontend/src/pages/Indexes.tsx
+++ b/platform/frontend/src/pages/Indexes.tsx
@@ -1,62 +1,70 @@
-import { useState, useEffect, useCallback } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { api, KnowledgeBaseIndex } from '../api/client'
 import { IndexCard } from '../components/indexes/IndexCard'
-import { Search, Filter, Loader2 } from 'lucide-react'
+import { AlertCircle, Filter, Loader2, Search } from 'lucide-react'
+import { PaginationFooter } from '@/components/ui/PaginationFooter'
 
 export function Indexes() {
   const navigate = useNavigate()
   const [searchParams, setSearchParams] = useSearchParams()
-  const [indexes, setIndexes] = useState<KnowledgeBaseIndex[]>([])
-  const [loading, setLoading] = useState(true)
+  const queryClient = useQueryClient()
+  const pageSize = 20
 
   const statusFilter = searchParams.get('status') || ''
+  const projectFilter = searchParams.get('project') || ''
   const search = searchParams.get('search') || ''
+  const offsetParam = Number(searchParams.get('offset') || '0')
+  const offset = Number.isFinite(offsetParam) && offsetParam > 0 ? offsetParam : 0
 
-  const fetchIndexes = useCallback(async () => {
-    setLoading(true)
-    try {
-      const response = await api.indexes.list({
+  const indexesQuery = useQuery({
+    queryKey: ['indexes', 'global', statusFilter, projectFilter, offset],
+    queryFn: () =>
+      api.indexes.list({
         status: statusFilter || undefined,
-        limit: 50
-      })
-      setIndexes(response.data.items)
-    } catch (err) {
-      console.error('Failed to fetch indexes', err)
-    } finally {
-      setLoading(false)
-    }
-  }, [statusFilter])
+        project_id: projectFilter || undefined,
+        limit: pageSize,
+        offset,
+      }),
+  })
 
-  useEffect(() => {
-    fetchIndexes()
-  }, [fetchIndexes])
+  const projectsQuery = useQuery({
+    queryKey: ['projects', 'index-filter-options'],
+    queryFn: () => api.projects.list({ limit: 100 }),
+  })
 
-  const handleFilterChange = (status: string) => {
+  const updateParam = (key: string, value: string) => {
     const next = new URLSearchParams(searchParams)
-    if (status) next.set('status', status)
-    else next.delete('status')
+    if (value) next.set(key, value)
+    else next.delete(key)
+    next.delete('offset')
     setSearchParams(next)
   }
 
   const handleSearchChange = (value: string) => {
-    const next = new URLSearchParams(searchParams)
-    if (value.trim()) next.set('search', value)
-    else next.delete('search')
-    setSearchParams(next)
+    updateParam('search', value.trim())
   }
 
+  const indexes = indexesQuery.data?.data.items ?? []
   const filteredIndexes = indexes.filter((index) => {
     const query = search.trim().toLowerCase()
     if (!query) return true
 
     return [
       index.name,
+      index.project_name,
       index.knowledge_base_name,
       index.rag_config_name,
       index.status,
     ].some((value) => value?.toLowerCase().includes(query))
   })
+
+  const handlePageChange = (nextOffset: number) => {
+    const next = new URLSearchParams(searchParams)
+    if (nextOffset > 0) next.set('offset', String(nextOffset))
+    else next.delete('offset')
+    setSearchParams(next)
+  }
 
   const runEvaluationFromIndex = (index: KnowledgeBaseIndex) => {
     if (!index.project_id) return
@@ -74,28 +82,41 @@ export function Indexes() {
     <div className="space-y-6">
       <div className="flex justify-between items-center">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">Indexes</h1>
-          <p className="text-gray-500 mt-1">Manage your knowledge base indexes and their build status</p>
+          <h1 className="text-2xl font-bold text-foreground">Indexes</h1>
+          <p className="text-muted-foreground mt-1">Monitor index build status across projects.</p>
         </div>
       </div>
 
-      <div className="bg-white p-4 rounded-lg border shadow-sm flex gap-4">
+      <div className="rounded-xl border border-border bg-card p-4 grid gap-4 lg:grid-cols-[1fr_14rem_14rem]">
         <div className="relative flex-1">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
           <input
             type="text"
             placeholder="Search indexes..."
-            className="w-full pl-9 pr-4 py-2 border rounded-md focus:ring-2 focus:ring-blue-500 outline-none"
+            className="h-10 w-full rounded-lg border border-input bg-background pl-9 pr-4 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
             value={search}
             onChange={(event) => handleSearchChange(event.target.value)}
           />
         </div>
-        <div className="relative w-48">
-          <Filter className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+        <div className="relative">
+          <Filter className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <select
+            value={projectFilter}
+            onChange={(e) => updateParam('project', e.target.value)}
+            className="h-10 w-full appearance-none rounded-lg border border-input bg-background pl-9 pr-4 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <option value="">All projects</option>
+            {(projectsQuery.data?.data.items ?? []).map((project) => (
+              <option key={project.id} value={project.id}>{project.name}</option>
+            ))}
+          </select>
+        </div>
+        <div className="relative">
+          <Filter className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
           <select
             value={statusFilter}
-            onChange={(e) => handleFilterChange(e.target.value)}
-            className="w-full pl-9 pr-4 py-2 border rounded-md focus:ring-2 focus:ring-blue-500 outline-none appearance-none bg-white"
+            onChange={(e) => updateParam('status', e.target.value)}
+            className="h-10 w-full appearance-none rounded-lg border border-input bg-background pl-9 pr-4 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
             <option value="">All Statuses</option>
             <option value="ready">Ready</option>
@@ -106,27 +127,44 @@ export function Indexes() {
         </div>
       </div>
 
-      {loading ? (
+      {indexesQuery.isLoading ? (
         <div className="flex justify-center py-12">
-          <Loader2 className="h-8 w-8 animate-spin text-blue-500" />
+          <Loader2 className="h-8 w-8 animate-spin text-primary" />
+        </div>
+      ) : indexesQuery.isError ? (
+        <div className="flex flex-col items-center justify-center rounded-xl border border-dashed border-border bg-card/50 py-12 text-center">
+          <AlertCircle className="h-10 w-10 text-destructive" />
+          <p className="mt-3 font-semibold text-foreground">Failed to load indexes</p>
+          <p className="mt-1 text-sm text-muted-foreground">Check the API connection and try again.</p>
         </div>
       ) : filteredIndexes.length === 0 ? (
-        <div className="text-center py-12 bg-gray-50 rounded-lg border border-dashed">
-          <p className="text-gray-500">No indexes found.</p>
-          <p className="text-sm text-gray-400 mt-1">
+        <div className="rounded-xl border border-dashed border-border bg-card/50 py-12 text-center">
+          <p className="text-muted-foreground">No indexes found.</p>
+          <p className="text-sm text-muted-foreground/80 mt-1">
             {search ? 'Clear search or filters to see more indexes.' : 'Go to a Knowledge Base to create an index.'}
           </p>
         </div>
       ) : (
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {filteredIndexes.map(index => (
-            <IndexCard
-              key={index.id}
-              index={index}
-              onDelete={fetchIndexes}
-              onRunEvaluation={index.project_id ? () => runEvaluationFromIndex(index) : undefined}
+        <div className="space-y-4">
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {filteredIndexes.map(index => (
+              <IndexCard
+                key={index.id}
+                index={index}
+                onDelete={() => queryClient.invalidateQueries({ queryKey: ['indexes'] })}
+                onRunEvaluation={index.project_id ? () => runEvaluationFromIndex(index) : undefined}
+              />
+            ))}
+          </div>
+          <div className="overflow-hidden rounded-xl border border-border bg-card">
+            <PaginationFooter
+              total={indexesQuery.data?.data.total ?? 0}
+              offset={indexesQuery.data?.data.offset ?? offset}
+              limit={indexesQuery.data?.data.limit ?? pageSize}
+              onPageChange={handlePageChange}
+              isLoading={indexesQuery.isFetching}
             />
-          ))}
+          </div>
         </div>
       )}
     </div>

--- a/platform/frontend/src/pages/KBDetail.tsx
+++ b/platform/frontend/src/pages/KBDetail.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react'
-import { useParams, useNavigate } from 'react-router-dom'
+import { useParams, useNavigate, useSearchParams } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import {
     ArrowLeft,
@@ -12,26 +12,43 @@ import {
     Clock,
     CheckCircle2,
     FileBox,
-    Layers
+    Layers,
+    Search
 } from 'lucide-react'
 import { api, KnowledgeBaseIndex } from '@/api/client'
 import { cn } from '@/lib/utils'
 import { CreateIndexDialog } from '@/components/indexes/CreateIndexDialog'
 import { IndexCard } from '@/components/indexes/IndexCard'
 import { useToast } from '@/components/ui/toast-context'
+import { PaginationFooter } from '@/components/ui/PaginationFooter'
 
 export function KBDetail() {
     const { id } = useParams<{ id: string }>()
     const navigate = useNavigate()
+    const [searchParams, setSearchParams] = useSearchParams()
     const queryClient = useQueryClient()
     const [isUploading, setIsUploading] = useState(false)
     const { success, error } = useToast()
     const [indexes, setIndexes] = useState<KnowledgeBaseIndex[]>([])
     const [isIndexDialogOpen, setIsIndexDialogOpen] = useState(false)
+    const documentPageSize = 20
+    const documentSearch = searchParams.get('docSearch') || ''
+    const documentOffsetParam = Number(searchParams.get('docOffset') || '0')
+    const documentOffset = Number.isFinite(documentOffsetParam) && documentOffsetParam > 0 ? documentOffsetParam : 0
 
     const { data: kb, isLoading, isError } = useQuery({
         queryKey: ['knowledge-base', id],
         queryFn: () => api.knowledgeBases.get(id!),
+        enabled: !!id,
+    })
+
+    const { data: documentsData, isLoading: isLoadingDocuments } = useQuery({
+        queryKey: ['knowledge-base-documents', id, documentSearch, documentOffset],
+        queryFn: () => api.knowledgeBases.listDocuments(id!, {
+            limit: documentPageSize,
+            offset: documentOffset,
+            search: documentSearch || undefined,
+        }),
         enabled: !!id,
     })
 
@@ -53,6 +70,7 @@ export function KBDetail() {
         mutationFn: (docId: string) => api.knowledgeBases.deleteDocument(id!, docId),
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: ['knowledge-base', id] })
+            queryClient.invalidateQueries({ queryKey: ['knowledge-base-documents', id] })
             success('Document deleted', 'The document has been removed.')
         },
         onError: () => {
@@ -68,6 +86,7 @@ export function KBDetail() {
         try {
             const result = await api.knowledgeBases.uploadDocuments(id!, files)
             queryClient.invalidateQueries({ queryKey: ['knowledge-base', id] })
+            queryClient.invalidateQueries({ queryKey: ['knowledge-base-documents', id] })
             const uploadedCount = result.data.uploaded.length
             success('Upload complete', `${uploadedCount} document${uploadedCount !== 1 ? 's' : ''} uploaded.`)
         } catch (err) {
@@ -77,6 +96,32 @@ export function KBDetail() {
             setIsUploading(false)
             e.target.value = ''
         }
+    }
+
+    const updateDocumentSearch = (value: string) => {
+        const next = new URLSearchParams(searchParams)
+        if (value.trim()) {
+            next.set('docSearch', value)
+        } else {
+            next.delete('docSearch')
+        }
+        next.delete('docOffset')
+        setSearchParams(next)
+    }
+
+    const updateDocumentOffset = (nextOffset: number) => {
+        const next = new URLSearchParams(searchParams)
+        if (nextOffset > 0) {
+            next.set('docOffset', String(nextOffset))
+        } else {
+            next.delete('docOffset')
+        }
+        setSearchParams(next)
+    }
+
+    const handleDeleteDocument = (docId: string, filename: string) => {
+        if (!confirm(`Delete "${filename}"? This removes the document from the knowledge base.`)) return
+        deleteDocMutation.mutate(docId)
     }
 
     if (isLoading) {
@@ -103,7 +148,8 @@ export function KBDetail() {
     }
 
     const k = kb.data
-    const documents = k.documents || []
+    const documents = documentsData?.data.items || []
+    const documentTotal = documentsData?.data.total ?? k.document_count
 
     return (
         <div className="space-y-6 pb-12">
@@ -155,18 +201,32 @@ export function KBDetail() {
             <div className="grid gap-6 md:grid-cols-3">
                 <div className="md:col-span-2 space-y-6">
                     <div className="rounded-xl border border-border bg-card overflow-hidden">
-                        <div className="border-b border-border bg-muted/30 px-6 py-4">
+                        <div className="flex flex-col gap-3 border-b border-border bg-muted/30 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
                             <h3 className="font-semibold flex items-center gap-2">
                                 <FileBox className="h-4 w-4 text-muted-foreground" />
-                                Documents ({documents.length})
+                                Documents ({documentTotal})
                             </h3>
+                            <div className="relative w-full sm:w-72">
+                                <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                                <input
+                                    type="text"
+                                    value={documentSearch}
+                                    onChange={(event) => updateDocumentSearch(event.target.value)}
+                                    placeholder="Search filenames..."
+                                    className="h-9 w-full rounded-lg border border-input bg-background pl-9 pr-3 text-sm"
+                                />
+                            </div>
                         </div>
 
                         <div className="divide-y divide-border">
-                            {documents.length === 0 ? (
+                            {isLoadingDocuments ? (
+                                <div className="flex justify-center py-12">
+                                    <Loader2 className="h-6 w-6 animate-spin text-primary/50" />
+                                </div>
+                            ) : documents.length === 0 ? (
                                 <div className="py-12 text-center text-muted-foreground">
                                     <FileText className="h-10 w-10 mx-auto opacity-20 mb-3" />
-                                    <p>No documents uploaded yet.</p>
+                                    <p>{documentSearch ? 'No documents match your search.' : 'No documents uploaded yet.'}</p>
                                 </div>
                             ) : (
                                 documents.map((doc) => (
@@ -192,7 +252,7 @@ export function KBDetail() {
                                                 {doc.status}
                                             </div>
                                             <button
-                                                onClick={() => deleteDocMutation.mutate(doc.id)}
+                                                onClick={() => handleDeleteDocument(doc.id, doc.filename)}
                                                 className="rounded-md p-1.5 text-muted-foreground hover:bg-destructive/10 hover:text-destructive transition-colors opacity-0 group-hover:opacity-100"
                                             >
                                                 <Trash2 className="h-4 w-4" />
@@ -202,6 +262,13 @@ export function KBDetail() {
                                 ))
                             )}
                         </div>
+                        <PaginationFooter
+                            total={documentTotal}
+                            offset={documentsData?.data.offset ?? documentOffset}
+                            limit={documentsData?.data.limit ?? documentPageSize}
+                            onPageChange={updateDocumentOffset}
+                            isLoading={isLoadingDocuments}
+                        />
                     </div>
                 </div>
 
@@ -221,9 +288,9 @@ export function KBDetail() {
                                 <span className="font-medium font-mono text-xs">v{k.current_version}</span>
                             </div>
                             <div className="flex justify-between items-center text-sm">
-                                <span className="text-muted-foreground">Total Size</span>
+                                <span className="text-muted-foreground">Documents</span>
                                 <span className="font-medium">
-                                    {(documents.reduce((acc, doc) => acc + doc.size_bytes, 0) / (1024 * 1024)).toFixed(2)} MB
+                                    {k.document_count}
                                 </span>
                             </div>
                         </div>
@@ -231,7 +298,7 @@ export function KBDetail() {
                         <button
                             onClick={() => setIsIndexDialogOpen(true)}
                             className="w-full mt-6 flex items-center justify-center gap-2 rounded-lg bg-primary px-4 py-2.5 text-sm font-bold text-primary-foreground hover:bg-primary/90 transition-all shadow-md disabled:opacity-50"
-                            disabled={documents.length === 0}
+                            disabled={k.document_count === 0}
                         >
                             <Layers className="h-4 w-4" />
                             Create Index
@@ -260,7 +327,7 @@ export function KBDetail() {
                         <button
                             onClick={() => setIsIndexDialogOpen(true)}
                             className="mt-4 text-primary hover:underline text-sm"
-                            disabled={documents.length === 0}
+                            disabled={k.document_count === 0}
                         >
                             Create your first index
                         </button>

--- a/platform/frontend/src/pages/ProjectDetail.tsx
+++ b/platform/frontend/src/pages/ProjectDetail.tsx
@@ -33,13 +33,12 @@ import { RAGConfigDialog } from '@/components/rag-configs/RAGConfigDialog'
 import { KBList } from '@/components/knowledge-bases/KBList'
 import { CreateKBDialog } from '@/components/knowledge-bases/CreateKBDialog'
 import { StartEvaluationWizard } from '@/components/evaluations/StartEvaluationWizard'
-import { EvaluationProgress } from '@/components/evaluations/EvaluationProgress'
-import { EvaluationResults } from '@/components/evaluations/EvaluationResults'
 import { TrendChart } from '@/components/trends/TrendChart'
 import { EfficiencyMap } from '@/components/trends/EfficiencyMap'
 import { ComparisonsTab } from '@/components/comparisons/ComparisonsTab'
 import { EditProjectDialog } from '@/components/projects/EditProjectDialog'
 import { IndexCard } from '@/components/indexes/IndexCard'
+import { PaginationFooter } from '@/components/ui/PaginationFooter'
 
 function ProjectOverviewTab({
     project,
@@ -591,19 +590,76 @@ function EvaluationsTab({
     initialIndexId?: string
 }) {
     const navigate = useNavigate()
+    const [searchParams, setSearchParams] = useSearchParams()
     const [isWizardOpen, setIsWizardOpen] = useState(false)
-    const [activeEvaluationId, setActiveEvaluationId] = useState<string | null>(null)
     const [hasAutoOpened, setHasAutoOpened] = useState(false)
     const queryClient = useQueryClient()
+    const pageSize = 20
+    const offsetParam = Number(searchParams.get('evalOffset') || '0')
+    const offset = Number.isFinite(offsetParam) && offsetParam > 0 ? offsetParam : 0
+    const statusFilter = searchParams.get('evalStatus') || ''
+    const testSetFilter = searchParams.get('evalTestSet') || ''
+    const ragConfigFilter = searchParams.get('evalRagConfig') || ''
+    const indexFilter = searchParams.get('evalIndex') || ''
 
     const { data, isLoading } = useQuery({
-        queryKey: ['evaluations', projectId],
-        queryFn: () => api.evaluations.list(projectId),
+        queryKey: ['evaluations', projectId, statusFilter, testSetFilter, ragConfigFilter, indexFilter, offset],
+        queryFn: () => api.evaluations.list(projectId, {
+            limit: pageSize,
+            offset,
+            status: statusFilter || undefined,
+            test_set_id: testSetFilter || undefined,
+            rag_config_id: ragConfigFilter || undefined,
+            knowledge_base_index_id: indexFilter || undefined,
+        }),
+        enabled: !!projectId,
+    })
+
+    const { data: testSetsData } = useQuery({
+        queryKey: ['test-sets', projectId, 'eval-filter-options'],
+        queryFn: () => api.testSets.list(projectId, { limit: 100 }),
+        enabled: !!projectId,
+    })
+    const { data: ragConfigsData } = useQuery({
+        queryKey: ['rag-configs', projectId, 'eval-filter-options'],
+        queryFn: () => api.ragConfigs.list(projectId, { limit: 100 }),
+        enabled: !!projectId,
+    })
+    const { data: indexesData } = useQuery({
+        queryKey: ['indexes', projectId, 'eval-filter-options'],
+        queryFn: () => api.indexes.list({ project_id: projectId, limit: 100 }),
         enabled: !!projectId,
     })
 
     const evaluations = data?.data?.items || []
-    const activeEvaluation = evaluations.find(e => e.id === activeEvaluationId)
+    const hasFilters = Boolean(statusFilter || testSetFilter || ragConfigFilter || indexFilter)
+    const total = data?.data?.total ?? 0
+    const testSets = testSetsData?.data.items ?? []
+    const ragConfigs = ragConfigsData?.data.items ?? []
+    const indexes = indexesData?.data.items ?? []
+
+    const updateEvaluationParam = (key: string, value: string) => {
+        const next = new URLSearchParams(searchParams)
+        next.set('tab', 'evals')
+        if (value) {
+            next.set(key, value)
+        } else {
+            next.delete(key)
+        }
+        next.delete('evalOffset')
+        setSearchParams(next)
+    }
+
+    const updateEvaluationOffset = (nextOffset: number) => {
+        const next = new URLSearchParams(searchParams)
+        next.set('tab', 'evals')
+        if (nextOffset > 0) {
+            next.set('evalOffset', String(nextOffset))
+        } else {
+            next.delete('evalOffset')
+        }
+        setSearchParams(next)
+    }
 
     useEffect(() => {
         if (launchWizard && !hasAutoOpened) {
@@ -611,52 +667,6 @@ function EvaluationsTab({
             setHasAutoOpened(true)
         }
     }, [launchWizard, hasAutoOpened])
-
-    if (activeEvaluationId) {
-        const closeActiveEvaluation = () => {
-            setActiveEvaluationId(null)
-            queryClient.invalidateQueries({ queryKey: ['evaluations', projectId] })
-        }
-        const hasSavedResults = (activeEvaluation?.result_count ?? 0) > 0
-        const canShowPartialResults =
-            (activeEvaluation?.status === 'failed' || activeEvaluation?.status === 'cancelled') && hasSavedResults
-
-        if (activeEvaluation?.status === 'completed') {
-            return (
-                <EvaluationResults
-                    evaluationId={activeEvaluationId}
-                    onBack={closeActiveEvaluation}
-                />
-            )
-        }
-
-        return (
-            <div className="space-y-6">
-                <button
-                    onClick={closeActiveEvaluation}
-                    className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
-                >
-                    <ArrowLeft className="h-4 w-4" />
-                    Back to Evaluations
-                </button>
-                <EvaluationProgress
-                    evaluationId={activeEvaluationId}
-                    evaluation={activeEvaluation}
-                    onRetryStarted={() => {
-                        queryClient.invalidateQueries({ queryKey: ['evaluation', activeEvaluationId] })
-                        queryClient.invalidateQueries({ queryKey: ['evaluations', projectId] })
-                    }}
-                    onClose={closeActiveEvaluation}
-                />
-                {canShowPartialResults && (
-                    <EvaluationResults
-                        evaluationId={activeEvaluationId}
-                        onBack={closeActiveEvaluation}
-                    />
-                )}
-            </div>
-        )
-    }
 
     if (isLoading) {
         return (
@@ -683,90 +693,160 @@ function EvaluationsTab({
                 </button>
             </div>
 
+            <div className="grid gap-3 rounded-xl border border-border bg-card p-4 md:grid-cols-4">
+                <select
+                    value={testSetFilter}
+                    onChange={(event) => updateEvaluationParam('evalTestSet', event.target.value)}
+                    className="h-10 rounded-lg border border-input bg-background px-3 text-sm"
+                >
+                    <option value="">All test sets</option>
+                    {testSets.map((testSet) => (
+                        <option key={testSet.id} value={testSet.id}>{testSet.name}</option>
+                    ))}
+                </select>
+                <select
+                    value={ragConfigFilter}
+                    onChange={(event) => updateEvaluationParam('evalRagConfig', event.target.value)}
+                    className="h-10 rounded-lg border border-input bg-background px-3 text-sm"
+                >
+                    <option value="">All RAG configs</option>
+                    {ragConfigs.map((config) => (
+                        <option key={config.id} value={config.id}>{config.name}</option>
+                    ))}
+                </select>
+                <select
+                    value={indexFilter}
+                    onChange={(event) => updateEvaluationParam('evalIndex', event.target.value)}
+                    className="h-10 rounded-lg border border-input bg-background px-3 text-sm"
+                >
+                    <option value="">All indexes</option>
+                    {indexes.map((index) => (
+                        <option key={index.id} value={index.id}>{index.name}</option>
+                    ))}
+                </select>
+                <select
+                    value={statusFilter}
+                    onChange={(event) => updateEvaluationParam('evalStatus', event.target.value)}
+                    className="h-10 rounded-lg border border-input bg-background px-3 text-sm"
+                >
+                    <option value="">All statuses</option>
+                    <option value="pending">Pending</option>
+                    <option value="running">Running</option>
+                    <option value="completed">Completed</option>
+                    <option value="failed">Failed</option>
+                    <option value="cancelled">Cancelled</option>
+                    <option value="paused">Paused</option>
+                </select>
+            </div>
+
             {evaluations.length === 0 ? (
                 <div className="flex flex-col items-center justify-center rounded-xl border border-dashed border-border py-20 bg-card/50">
                     <div className="rounded-full bg-primary/10 p-5 text-primary">
                         <FlaskConical className="h-10 w-10" />
                     </div>
-                    <h3 className="mt-5 text-xl font-semibold">No evaluations yet</h3>
+                    <h3 className="mt-5 text-xl font-semibold">{hasFilters ? 'No matching evaluations' : 'No evaluations yet'}</h3>
                     <p className="mt-2 text-center text-muted-foreground max-w-sm">
-                        Start your first RAG evaluation to measure performance across different metrics.
+                        {hasFilters
+                            ? 'Clear filters or adjust the selected context to see more evaluations.'
+                            : 'Start your first RAG evaluation to measure performance across different metrics.'}
                     </p>
-                    <button
-                        onClick={() => setIsWizardOpen(true)}
-                        className="mt-6 flex items-center gap-2 rounded-lg bg-primary px-6 py-2.5 text-sm font-semibold text-primary-foreground hover:bg-primary/90 transition-all shadow-md"
-                    >
-                        <Play className="h-4 w-4" />
-                        Start First Evaluation
-                    </button>
+                    {!hasFilters && (
+                        <button
+                            onClick={() => setIsWizardOpen(true)}
+                            className="mt-6 flex items-center gap-2 rounded-lg bg-primary px-6 py-2.5 text-sm font-semibold text-primary-foreground hover:bg-primary/90 transition-all shadow-md"
+                        >
+                            <Play className="h-4 w-4" />
+                            Start First Evaluation
+                        </button>
+                    )}
                 </div>
             ) : (
-                <div className="grid gap-4">
-                    {evaluations.map((evalItem: Evaluation) => (
-                        <div
-                            key={evalItem.id}
-                            className="group relative flex items-center justify-between rounded-xl border border-border bg-card p-4 hover:border-primary/50 hover:shadow-md transition-all cursor-pointer"
-                            onClick={() => navigate(`/projects/${projectId}/evaluations/${evalItem.id}`)}
-                        >
-                            <div className="flex items-center gap-4">
-                                <div className={cn(
-                                    "flex h-10 w-10 items-center justify-center rounded-lg",
-                                    evalItem.status === 'completed' ? "bg-green-500/10 text-green-600" :
-                                        evalItem.status === 'failed' ? "bg-red-500/10 text-red-600" :
-                                            evalItem.status === 'running' ? "bg-blue-500/10 text-blue-600 animate-pulse" :
-                                                "bg-muted text-muted-foreground"
-                                )}>
-                                    <FlaskConical className="h-5 w-5" />
-                                </div>
-                                <div>
-                                    <div className="flex items-center gap-2">
-                                        <p className="font-bold">{evalItem.name || `Evaluation #${evalItem.id.slice(0, 8)}`}</p>
-                                        <span className={cn(
-                                            "rounded-full px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider",
-                                            evalItem.status === 'completed' ? "bg-green-500/10 text-green-600" :
-                                                evalItem.status === 'failed' ? "bg-red-500/10 text-red-600" :
-                                                    evalItem.status === 'running' ? "bg-blue-500/10 text-blue-600" :
-                                                        "bg-muted text-muted-foreground"
-                                        )}>
-                                            {evalItem.status}
-                                        </span>
+                <div className="overflow-hidden rounded-xl border border-border bg-card">
+                    <div className="divide-y divide-border">
+                        {evaluations.map((evalItem: Evaluation) => (
+                            <div
+                                key={evalItem.id}
+                                className="group relative flex cursor-pointer flex-col gap-4 p-4 transition-all hover:bg-accent/40 lg:flex-row lg:items-center lg:justify-between"
+                                onClick={() => navigate(`/projects/${projectId}/evaluations/${evalItem.id}`)}
+                            >
+                                <div className="flex items-start gap-4">
+                                    <div className={cn(
+                                        "flex h-10 w-10 shrink-0 items-center justify-center rounded-lg",
+                                        evalItem.status === 'completed' ? "bg-green-500/10 text-green-600" :
+                                            evalItem.status === 'failed' ? "bg-red-500/10 text-red-600" :
+                                                evalItem.status === 'running' ? "bg-blue-500/10 text-blue-600 animate-pulse" :
+                                                    "bg-muted text-muted-foreground"
+                                    )}>
+                                        <FlaskConical className="h-5 w-5" />
                                     </div>
-                                    <div className="flex items-center gap-3 mt-1 text-xs text-muted-foreground font-medium">
-                                        <div className="flex items-center gap-1">
-                                            <Calendar className="h-3 w-3" />
-                                            {new Date(evalItem.created_at).toLocaleString()}
+                                    <div className="min-w-0">
+                                        <div className="flex flex-wrap items-center gap-2">
+                                            <p className="font-bold">{evalItem.name || `Evaluation #${evalItem.id.slice(0, 8)}`}</p>
+                                            <span className={cn(
+                                                "rounded-full px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider",
+                                                evalItem.status === 'completed' ? "bg-green-500/10 text-green-600" :
+                                                    evalItem.status === 'failed' ? "bg-red-500/10 text-red-600" :
+                                                        evalItem.status === 'running' ? "bg-blue-500/10 text-blue-600" :
+                                                            "bg-muted text-muted-foreground"
+                                            )}>
+                                                {evalItem.status}
+                                            </span>
+                                            {evalItem.is_baseline && (
+                                                <span className="rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-primary">
+                                                    Baseline
+                                                </span>
+                                            )}
                                         </div>
-                                        <div>{evalItem.result_count} results</div>
+                                        <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                                            <span className="flex items-center gap-1">
+                                                <Calendar className="h-3 w-3" />
+                                                {new Date(evalItem.created_at).toLocaleString()}
+                                            </span>
+                                            <span>{evalItem.result_count} results</span>
+                                            {evalItem.test_set_name && <span>Test: {evalItem.test_set_name}</span>}
+                                            {evalItem.index_name && <span>Index: {evalItem.index_name}</span>}
+                                            {evalItem.rag_type && <span>RAG: {evalItem.rag_type}</span>}
+                                        </div>
                                     </div>
                                 </div>
-                            </div>
 
-                            <div className="flex items-center gap-6">
-                                {evalItem.pass_rate !== null && (
-                                    <div className="text-right">
-                                        <p className="text-[10px] font-bold uppercase text-muted-foreground">Pass Rate</p>
-                                        <p className={cn(
-                                            "text-lg font-black",
-                                            evalItem.pass_rate >= 0.7 ? "text-green-500" : "text-amber-500"
-                                        )}>
-                                            {(evalItem.pass_rate * 100).toFixed(0)}%
-                                        </p>
+                                <div className="flex items-center justify-between gap-6 lg:justify-end">
+                                    <div className="flex items-center gap-6">
+                                        {evalItem.pass_rate !== null && (
+                                            <div className="text-right">
+                                                <p className="text-[10px] font-bold uppercase text-muted-foreground">Pass Rate</p>
+                                                <p className={cn(
+                                                    "text-lg font-black",
+                                                    evalItem.pass_rate >= 0.7 ? "text-green-500" :
+                                                        evalItem.pass_rate >= 0.4 ? "text-amber-500" : "text-red-500"
+                                                )}>
+                                                    {(evalItem.pass_rate * 100).toFixed(0)}%
+                                                </p>
+                                            </div>
+                                        )}
+                                        {evalItem.summary_metrics?.overall_avg !== undefined && (
+                                            <div className="text-right">
+                                                <p className="text-[10px] font-bold uppercase text-muted-foreground">Avg Score</p>
+                                                <p className="text-lg font-black text-primary">
+                                                    {evalItem.summary_metrics.overall_avg.toFixed(2)}
+                                                </p>
+                                            </div>
+                                        )}
                                     </div>
-                                )}
-                                {evalItem.summary_metrics?.overall_avg !== undefined && (
-                                    <div className="text-right">
-                                        <p className="text-[10px] font-bold uppercase text-muted-foreground">Avg Score</p>
-                                        <p className="text-lg font-black text-primary">
-                                            {evalItem.summary_metrics.overall_avg.toFixed(2)}
-                                        </p>
+                                    <div className="rounded-full bg-muted/50 p-2 transition-all group-hover:bg-primary group-hover:text-primary-foreground">
+                                        <ChevronRight className="h-4 w-4" />
                                     </div>
-                                )}
-                                <div className="rounded-full p-2 bg-muted/50 group-hover:bg-primary group-hover:text-primary-foreground transition-all">
-                                    <ChevronRight className="h-4 w-4" />
                                 </div>
                             </div>
-                        </div>
-                    ))}
+                        ))}
+                    </div>
+                    <PaginationFooter
+                        total={total}
+                        offset={data?.data?.offset ?? offset}
+                        limit={data?.data?.limit ?? pageSize}
+                        onPageChange={updateEvaluationOffset}
+                        isLoading={isLoading}
+                    />
                 </div>
             )}
 


### PR DESCRIPTION
## Summary

Ports the UI review follow-up work onto the current `main` branch as a clean one-commit PR.

Changes include:
- evaluation list result counts, context fields, and filters
- server-side evaluation result search and pagination
- paginated knowledge base documents endpoint and KB detail pagination/delete confirmation
- shared `PaginationFooter`
- React Query, filtering, error state, pagination, and design-token updates for the global Indexes page
- project context on index cards

## Validation

- `platform/backend`: `uv run ruff check .`
- `platform/backend`: `uv run pytest tests/test_api/test_evaluations.py::TestGetEvaluation::test_list_evaluations tests/test_api/test_evaluations.py::TestGetEvaluation::test_get_results_falls_back_to_ordered_test_cases`
- `platform/frontend`: `npm.cmd run lint`
- `platform/frontend`: `npm.cmd run build`

Note: broader backend pytest module runs exceeded local timeout in this environment, but collection and the targeted endpoint tests passed.